### PR TITLE
Support HEAD requests against tusd

### DIFF
--- a/Pod/Classes/TUSResumableUpload.m
+++ b/Pod/Classes/TUSResumableUpload.m
@@ -231,7 +231,7 @@ didReceiveResponse:(NSURLResponse *)response
     
     switch([self state]) {
         case CheckingFile: {
-            if ([httpResponse statusCode] != 200 || [httpResponse statusCode] != 201) {
+            if ([httpResponse statusCode] < 200 || [httpResponse statusCode] > 204) {
                 TUSLog(@"Server responded with %ld. Restarting upload",
                        (long)httpResponse.statusCode);
                 [self createFile];


### PR DESCRIPTION
The reference tusd implementation returns 204 codes for HEAD calls, which while not strictly to spec shouldn't cause an error.  The Android client is more forgiving than TUSKit as well.

Also, the current version will always fail, because the status code can't be both 200 AND 201, so one of the two statements will always evaluate as true.