### PR TITLE
Remove strong references to 'self' in callback

### DIFF
--- a/Example/TUSKit/TKViewController.m
+++ b/Example/TUSKit/TKViewController.m
@@ -13,7 +13,7 @@
 #import <AssetsLibrary/AssetsLibrary.h>
 #import <TUSKit/TUSKit.h>
 
-static NSString* const UPLOAD_ENDPOINT = @"http://192.168.5.80:1080/files/";
+static NSString* const UPLOAD_ENDPOINT = @"http://127.0.0.1:1080/files/";
 static NSString* const FILE_NAME = @"tuskit_example";
 
 @interface TKViewController ()

--- a/Pod/Classes/TUSResumableUpload.m
+++ b/Pod/Classes/TUSResumableUpload.m
@@ -267,7 +267,8 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     [mutableHeader setObject:[NSString stringWithFormat:@"%lld", size] forKey:HTTP_UPLOAD_LENGTH];
     [mutableHeader setObject:HTTP_TUS_VERSION forKey:HTTP_TUS];
     
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:self.delegate.createUploadURL
+    NSURL *createUploadURL = self.delegate.createUploadURL;
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:createUploadURL
                                                                 cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                             timeoutInterval:REQUEST_TIMEOUT];
     [request setHTTPMethod:HTTP_POST];
@@ -329,7 +330,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         } else {
             // Got a valid status code, so update url
             NSString *location = [httpResponse.allHeaderFields valueForKey:HTTP_LOCATION];
-            weakself.uploadUrl = [NSURL URLWithString:location relativeToURL:self.delegate.createUploadURL];
+            weakself.uploadUrl = [NSURL URLWithString:location relativeToURL:createUploadURL];
             if (weakself.uploadUrl) {
                 // If we got a valid URL, set the new state to uploading.  Otherwise, will try creating again.k
                 TUSLog(@"Created resumable upload at %@ for id %@", weakself.uploadUrl, weakself.uploadId);


### PR DESCRIPTION
Updates to 1.3.1 created a strong reference to 'self' in the URL callback.  

This:
- Removes the strong reference
- Ensures that the URL used to create the relative upload URL is always the same as that used for the creation, even if the delegate implementation changes
- Changes the example to point to localhost by default