### PR TITLE
Fixes for OSX

### DIFF
--- a/Pod/Classes/TUSResumableUpload.m
+++ b/Pod/Classes/TUSResumableUpload.m
@@ -349,7 +349,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
-            [weakself cancel];
+            // [weakself cancel];
         #endif
         
         if (delayTime > 0) {
@@ -455,7 +455,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
-            [weakself cancel];
+            // [weakself cancel];
         #endif
         if (delayTime > 0) {
             __weak NSOperationQueue *weakQueue = [NSOperationQueue currentQueue];
@@ -543,7 +543,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
-            [weakself cancel];
+            // [weakself cancel];
         #endif
         [weakself continueUpload]; // Continue upload, not resume, because we do not want to continue if cancelled.
     }];


### PR DESCRIPTION
Opening this PR as a point of discussion. I am a swift developer so my objective-c knowledge is a bit lacking. I have recently been integrating TUSKit into a macOS menubar app to allow drag and drop file uploads.

For macOS you can see the issue below where for iOS uploads are cancelled after an expiration time, but for macOS uploads are just cancelled, I am presuming I should implement similar functionality on macOS with a background task, just wondering if there are any pointers for this? DispatchQueue or OperationQueue etc? And is there a minimum supported macOS version or does that not really matter?

I am presuming given the issues here I am one of the first to use the library on macOS in a while, so we can maybe stick to 10.12 or 10.13?