### PR TITLE
Feature / Uploading files in chunks

### DIFF
--- a/Pod/Classes/TUSData.h
+++ b/Pod/Classes/TUSData.h
@@ -26,4 +26,10 @@
 - (void)setOffset:(long long)offset;
 - (BOOL)open; // Re-open a closed TUSData object if it can be. Return YES if the TUSData object is open after the call.
 - (void)close; // Close this TUSData object if it can be
+
+- (NSData*)dataChunk:(long long)chunkSize;
+
+- (NSData*)dataChunk:(long long)chunkSize
+          fromOffset: (NSUInteger)offset;
+
 @end

--- a/Pod/Classes/TUSData.m
+++ b/Pod/Classes/TUSData.m
@@ -44,6 +44,7 @@
 }
 
 #pragma mark - Public Methods
+
 - (NSInputStream*)dataStream
 {
     if (self.inputStream.streamStatus == NSStreamStatusClosed){
@@ -102,6 +103,15 @@
     return length;
 }
 
+
+- (NSData*)dataChunk:(long long)chunkSize {
+    return [self dataChunk:chunkSize fromOffset:_offset];
+}
+
+- (NSData*)dataChunk:(long long)chunkSize
+          fromOffset: (NSUInteger)offset {
+    return [_data subdataWithRange:NSMakeRange(offset, chunkSize)];
+}
 
 #pragma mark - NSStreamDelegate Protocol Methods
 - (void)stream:(NSStream *)aStream

--- a/Pod/Classes/TUSFileData.m
+++ b/Pod/Classes/TUSFileData.m
@@ -96,4 +96,12 @@
     }
     
 }
+
+- (NSData*)dataChunk:(long long)chunkSize
+          fromOffset: (NSUInteger)offset
+{
+    [self.fileHandle seekToFileOffset:offset];
+    NSData *chunkData = [self.fileHandle readDataOfLength:chunkSize];
+    return chunkData;
+}
 @end

--- a/Pod/Classes/TUSResumableUpload.h
+++ b/Pod/Classes/TUSResumableUpload.h
@@ -64,5 +64,11 @@ typedef void (^TUSUploadProgressBlock)(int64_t bytesWritten, int64_t bytesTotal)
  Resume the upload if it was cancelled or not yet started
  */
 - (BOOL) resume;
+
+/**
+ Lazily instantiate the chunkSize for the upload
+ */
+- (void)setChunkSize:(long long)chunkSize;
+
 @end
 

--- a/Pod/Classes/TUSResumableUpload.m
+++ b/Pod/Classes/TUSResumableUpload.m
@@ -203,8 +203,6 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     return [self continueUpload];
 }
 
-
-
 #pragma mark property getters and setters
 - (long long) length {
     return self.data.length;
@@ -507,9 +505,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     //If we are using chunked sizes, set the chunkSize and retrieve the data
     //with the offset and size of self.chunkSize
     if (self.chunkSize > 0) {
-        //[self.data setChunkSize:self.chunkSize];
         request.HTTPBody = [self.data dataChunk:self.chunkSize];
-        
         TUSLog(@"Uploading chunk sized %lu / %lld ", request.HTTPBody.length, self.chunkSize);
     } else {
         request.HTTPBodyStream = self.data.dataStream;

--- a/Pod/Classes/TUSSession.m
+++ b/Pod/Classes/TUSSession.m
@@ -95,7 +95,6 @@
     return upload;
 }
 
-
 /**
  Restore an upload, but do not start it.  Uploads must be restored by ID because file URLs can change between launch.
  */


### PR DESCRIPTION
Uploading files in chunks is rather mandatory for some online services (i.e. Cloudflare Stream) so this implements the chunked sends using the HTTPBody instead of HTTPBodyStream.