### PR TITLE
Support for app extension pod subspec

### DIFF
--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -17,12 +17,6 @@ Pod::Spec.new do |s|
   s.module_map = 'Supporting Files/module.modulemap'
   s.source_files = 'TUSKit/*.{h,m}', 'Supporting Files/*.{h}'
 
-#   s.default_subspec = 'Core'
-#
-#   s.subspec 'Core' do |core|
-#     core.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
-#   end
-
   s.subspec 'AppExtension' do |ext|
     ext.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
     # For app extensions, disabling code paths using unavailable API

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -16,5 +16,17 @@ Pod::Spec.new do |s|
   s.module_name = 'TUSKit'
   s.module_map = 'Supporting Files/module.modulemap'
   s.source_files = 'TUSKit/*.{h,m}', 'Supporting Files/*.{h}'
+
+#   s.default_subspec = 'Core'
+#
+#   s.subspec 'Core' do |core|
+#     core.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
+#   end
+
+  s.subspec 'AppExtension' do |ext|
+#     ext.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
+    # For app extensions, disabling code paths using unavailable API
+    ext.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'TUSKIT_APP_EXTENSIONS=1' }
+  end
 end
 

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 #   end
 
   s.subspec 'AppExtension' do |ext|
-#     ext.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
+    ext.source_files = 'TUSKit/*.{m,h}', 'Supporting Files/*.{h}'
     # For app extensions, disabling code paths using unavailable API
     ext.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'TUSKIT_APP_EXTENSIONS=1' }
   end

--- a/TUSKit/TUSResumableUpload.m
+++ b/TUSKit/TUSResumableUpload.m
@@ -328,7 +328,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     
     __weak TUSResumableUpload * weakself = self;
     
-    #if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
     UIBackgroundTaskIdentifier bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [weakself cancel];
     }];
@@ -406,7 +406,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         }
         weakself.idle = YES;
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
-        #if TARGET_OS_IPHONE
+        #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
             [weakself cancel];
@@ -449,7 +449,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     [request setAllHTTPHeaderFields:mutableHeader];
     
     __weak TUSResumableUpload * weakself = self;
-    #if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
         UIBackgroundTaskIdentifier bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [weakself cancel];
         }];
@@ -512,7 +512,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         }
         weakself.idle = YES;
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
-        #if TARGET_OS_IPHONE
+        #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
             [weakself cancel];
@@ -567,7 +567,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
     }
     
     __weak TUSResumableUpload * weakself = self;
-    #if TARGET_OS_IPHONE
+    #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
         UIBackgroundTaskIdentifier bgTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             [weakself cancel];
         }];
@@ -608,7 +608,7 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         }
         weakself.idle = YES;
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
-        #if TARGET_OS_IPHONE
+        #if TARGET_OS_IPHONE && !defined(TUSKIT_APP_EXTENSIONS)
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
         #elif defined TARGET_OS_OSX
             [weakself cancel];


### PR DESCRIPTION
Fixes #63 

Simply add support for `pod 'TUSKit/AppExtension'` whilst leaving the `pod 'TUSKit`.

We could add support for more AppExtension friendly apis here where `UIApplication.shared` isn't available