### PR TITLE
WIP: Add support for delegate callbacks on URLSession

### DIFF
--- a/TUSKit/TUSResumableUpload+Private.h
+++ b/TUSKit/TUSResumableUpload+Private.h
@@ -84,6 +84,9 @@
  */
 -(void)task:(NSURLSessionTask * _Nonnull)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend;
 
+
+-(void)task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error;
+
 /** Serialize to a dictionary for saving */
 -(NSDictionary * _Nonnull) serialize;
 @end

--- a/TUSKit/TUSResumableUpload.h
+++ b/TUSKit/TUSResumableUpload.h
@@ -70,5 +70,6 @@ typedef void (^TUSUploadProgressBlock)(int64_t bytesWritten, int64_t bytesTotal)
  */
 - (void)setChunkSize:(long long)chunkSize;
 
+- (void)task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error;
 @end
 

--- a/TUSKit/TUSSession.m
+++ b/TUSKit/TUSSession.m
@@ -242,4 +242,9 @@
     [self.tasks[task] task:task didSendBodyData:bytesSent totalBytesSent:totalBytesSent totalBytesExpectedToSend:totalBytesExpectedToSend];
 }
 
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+    [self.tasks[task] task:task didCompleteWithError:error];
+}
+
+
 @end


### PR DESCRIPTION
To follow on from #63 
It seems as though I've got an issue with `self` the code `cancels` and stops the process so when `continueUpload` is called it is stopped so doesn't continue uploading the file. Have I misunderstood how this should be working?

It seems the problem I've mentioned seems to be an issue on the current `develop` branch too. It calls through to create a file, gets a `201` but never starts uploading the file as the state is canceled.

It seems the culprit is the following block, it's cancelling the current request and not letting it continue I presume this isn't intentional

```
#elif defined TARGET_OS_OSX
            [weakself cancel];  <----
#endif
```