### PR TITLE
Fix mistake where uploads are cancel by mistake on macOS

### DIFF
--- a/Supporting Files/TUSKit.h
+++ b/Supporting Files/TUSKit.h
@@ -15,7 +15,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#define TUS_LOGGING_ENABLED 1
+#define TUS_LOGGING_ENABLED 0
 #if TUS_LOGGING_ENABLED
 #define TUSLog( s, ... ) NSLog( @"<%@:(%d)> %@", \
 [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \

--- a/Supporting Files/TUSKit.h
+++ b/Supporting Files/TUSKit.h
@@ -15,7 +15,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#define TUS_LOGGING_ENABLED 0
+#define TUS_LOGGING_ENABLED 1
 #if TUS_LOGGING_ENABLED
 #define TUSLog( s, ... ) NSLog( @"<%@:(%d)> %@", \
 [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \

--- a/TUSKit/TUSResumableUpload.m
+++ b/TUSKit/TUSResumableUpload.m
@@ -408,8 +408,6 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
-        #elif defined TARGET_OS_OSX
-            [weakself cancel];
         #endif
         
         if (delayTime > 0) {
@@ -514,8 +512,6 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
-        #elif defined TARGET_OS_OSX
-            [weakself cancel];
         #endif
         if (delayTime > 0) {
             __weak NSOperationQueue *weakQueue = [NSOperationQueue currentQueue];
@@ -610,8 +606,6 @@ typedef void(^NSURLSessionTaskCompletionHandler)(NSData * _Nullable data, NSURLR
         [weakself.delegate saveUpload:weakself]; // Save current state for reloading - only save when we get a call back, not at the start of one (because this is the only time the state changes)
         #if TARGET_OS_IPHONE
             [[UIApplication sharedApplication] endBackgroundTask:bgTask];
-        #elif defined TARGET_OS_OSX
-            [weakself cancel];
         #endif
         [weakself continueUpload]; // Continue upload, not resume, because we do not want to continue if cancelled.
     }];


### PR DESCRIPTION
In https://github.com/tus/TUSKit/commit/aad200876a80a8b48b4dcb366195290a58d73d8e some code was added that looks like a copy+paste error. The code is canceling uploads when I think it means to be ending a background task. I've removed that code here. After removing it my uploads from macOS now work. 