### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "TUSKit",
+    products: [
+        .library(name: "TUSKit", targets: ["TUSKit"]),
+    ],
+    targets: [
+        .target(name: "TUSKit", path: "TUSKit"),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Swift Rewrite of TUSKit 
 [![Protocol](http://img.shields.io/badge/tus_protocol-v1.0.0-blue.svg?style=flat)](http://tus.io/protocols/resumable-upload.html)
 [![Version](https://img.shields.io/cocoapods/v/TUSKit.svg?style=flat)](http://cocoadocs.org/docsets/TUSKit)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
 [![License](https://img.shields.io/cocoapods/l/TUSKit.svg?style=flat)](http://cocoadocs.org/docsets/TUSKit)
 [![Platform](https://img.shields.io/cocoapods/p/TUSKit.svg?style=flat)](http://cocoadocs.org/docsets/TUSKit)
 


### PR DESCRIPTION
These additions give developers the flexibility of using TUSKit with [Swift Package Manager](https://swift.org/package-manager/). For the time being, they'll simply need to specify the `swift-development` branch to use it. I've also added a small "SwiftPM compatible" badge at the top of the README, just for visibility.

Fixes #78