### PR TITLE
Add support for Upload-Metadata

### DIFF
--- a/Example/TUSKit/ViewController.swift
+++ b/Example/TUSKit/ViewController.swift
@@ -59,6 +59,7 @@ class ViewController: UIViewController, TUSDelegate, UIImagePickerControllerDele
             //When you have a file, create an upload, and give it a Id.
             var fileData = try! Data(contentsOf: file)
             let upload: TUSUpload = TUSUpload(withId:  String(number), andData: fileData, andFileType: "jpeg")
+            upload.metadata = ["hello": "world"]
             //Create or resume upload
             TUSClient.shared.createOrResume(forUpload: upload, withCustomHeaders: ["Header": "Value"])
         }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ var uploadObject = TUSUpload(withId: "Another Id to reference a file", andData: 
 //An existing upload
 var uploadObject = TUSUpload(withId: "Just an ID of a past upload") //Will fail out if data on the device matching the ID isn't found.
 
+//An upload with metadata
+var uploadObject = TUSUpload(withId: "Some Id to reference a file", andFile: "FilePathHere")
+uploadObject.metadata = ["hello": "world"]
+
 ```
 
 ## TUSClient

--- a/TUSKit/Classes/TUSClient.swift
+++ b/TUSKit/Classes/TUSClient.swift
@@ -79,25 +79,25 @@ public class TUSClient: NSObject, URLSessionTaskDelegate {
     ///   - upload: the upload object
     ///   - retries: number of retires to take if a call fails
     public func createOrResume(forUpload upload: TUSUpload, withRetries retries: Int) {
-        let fileName = String(format: "%@%@", upload.id!, upload.fileType!)
+        let fileName = String(format: "%@%@", upload.id, upload.fileType!)
         let tusName = String(format: "TUS-%@", fileName)
         
         
         if (fileManager.fileExists(withName: fileName) == false) {
-            logger.log(forLevel: .Info, withMessage:String(format: "File not found in local storage.", upload.id!))
+            logger.log(forLevel: .Info, withMessage:String(format: "File not found in local storage.", upload.id))
             upload.status = .new
             currentUploads?.append(upload)
             if (upload.filePath != nil) {
                 if fileManager.moveFile(atLocation: upload.filePath!, withFileName: fileName) == false{
                     //fail out
-                    logger.log(forLevel: .Error, withMessage:String(format: "Failed to move file.", upload.id!))
+                    logger.log(forLevel: .Error, withMessage:String(format: "Failed to move file.", upload.id))
 
                     return
                 }
             } else if(upload.data != nil) {
                 if fileManager.writeData(withData: upload.data!, andFileName: fileName) == false {
                     //fail out
-                    logger.log(forLevel: .Error, withMessage:String(format: "Failed to create file in local storage from data.", upload.id!))
+                    logger.log(forLevel: .Error, withMessage:String(format: "Failed to create file in local storage from data.", upload.id))
 
                     return
                 }
@@ -110,11 +110,11 @@ public class TUSClient: NSObject, URLSessionTaskDelegate {
             
             switch upload.status {
             case .paused, .created:
-                logger.log(forLevel: .Info, withMessage:String(format: "File %@ has been previously been created", upload.id!))
+                logger.log(forLevel: .Info, withMessage:String(format: "File %@ has been previously been created", upload.id))
                 executor.upload(forUpload: upload)
                 break
             case .new:
-                logger.log(forLevel: .Info, withMessage:String(format: "Creating file %@ on server", upload.id!))
+                logger.log(forLevel: .Info, withMessage:String(format: "Creating file %@ on server", upload.id))
                 upload.contentLength = "0"
                 upload.uploadOffset = "0"
                 upload.uploadLength = String(fileManager.sizeForLocalFilePath(filePath: String(format: "%@%@", fileManager.fileStorePath(), fileName)))
@@ -197,10 +197,10 @@ public class TUSClient: NSObject, URLSessionTaskDelegate {
     /// - Parameter upload: the upload object
     public func cleanUp(forUpload upload: TUSUpload) {
         //Delete stuff here
-        let fileName = String(format: "%@%@", upload.id!, upload.fileType!)
+        let fileName = String(format: "%@%@", upload.id, upload.fileType!)
         currentUploads?.remove(at: 0)
         fileManager.deleteFile(withName: fileName)
-        logger.log(forLevel: .Info, withMessage: "file \(upload.id!) cleaned up")
+        logger.log(forLevel: .Info, withMessage: "file \(upload.id) cleaned up")
     }
     
     public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {

--- a/TUSKit/Classes/TUSExecutor.swift
+++ b/TUSKit/Classes/TUSExecutor.swift
@@ -35,13 +35,13 @@ class TUSExecutor: NSObject, URLSessionDelegate {
     }
     
     internal func create(forUpload upload: TUSUpload) {
-        var request: URLRequest = urlRequest(withEndpoint: "", andMethod: "POST", andContentLength: upload.contentLength!, andUploadLength: upload.uploadLength!, andFilename: upload.id!, andHeaders: ["Upload-Extension": "creation"])
+        var request: URLRequest = urlRequest(withEndpoint: "", andMethod: "POST", andContentLength: upload.contentLength!, andUploadLength: upload.uploadLength!, andFilename: upload.id, andHeaders: ["Upload-Extension": "creation"])
         request.addValue(upload.contentLength!, forHTTPHeaderField: "Content-Length")
         request.addValue(upload.uploadLength!, forHTTPHeaderField: "Upload-Length")
         let task =  TUSClient.shared.tusSession.session.dataTask(with: request) { (data, response, error) in
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 201 {
-                    TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "File %@ created", upload.id!))
+                    TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "File %@ created", upload.id))
                     // Set the new status and other props for the upload
                     upload.status = .created
 //                    upload.contentLength = httpResponse.allHeaderFields["Content-Length"] as? String
@@ -62,9 +62,9 @@ class TUSExecutor: NSObject, URLSessionDelegate {
          */
         //First we create chunks
         //MARK: FIX THIS
-        TUSClient.shared.logger.log(forLevel: .Info, withMessage: String(format: "Preparing upload data for file %@", upload.id!))
-        let uploadData = try! Data(contentsOf: URL(fileURLWithPath: String(format: "%@%@%@", TUSClient.shared.fileManager.fileStorePath(), upload.id!, upload.fileType!)))
-        let fileName = String(format: "%@%@", upload.id!, upload.fileType!)
+        TUSClient.shared.logger.log(forLevel: .Info, withMessage: String(format: "Preparing upload data for file %@", upload.id))
+        let uploadData = try! Data(contentsOf: URL(fileURLWithPath: String(format: "%@%@%@", TUSClient.shared.fileManager.fileStorePath(), upload.id, upload.fileType!)))
+        let fileName = String(format: "%@%@", upload.id, upload.fileType!)
         let tusName = String(format: "TUS-%@", fileName)
         //let uploadData = try! UserDefaults.standard.data(forKey: tusName)
         //upload.data = uploadData
@@ -77,8 +77,8 @@ class TUSExecutor: NSObject, URLSessionDelegate {
     }
     
     private func upload(forChunks chunks: [Data], withUpload upload: TUSUpload, atPosition position: Int) {
-        TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "Upload starting for file %@ - Chunk %u / %u", upload.id!, position + 1, chunks.count))
-        let request: URLRequest = urlRequest(withFullURL: upload.uploadLocationURL!, andMethod: "PATCH", andContentLength: upload.contentLength!, andUploadLength: upload.uploadLength!, andFilename: upload.id!, andHeaders: ["Content-Type":"application/offset+octet-stream", "Upload-Offset": upload.uploadOffset!, "Content-Length": String(chunks[position].count)])
+        TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "Upload starting for file %@ - Chunk %u / %u", upload.id, position + 1, chunks.count))
+        let request: URLRequest = urlRequest(withFullURL: upload.uploadLocationURL!, andMethod: "PATCH", andContentLength: upload.contentLength!, andUploadLength: upload.uploadLength!, andFilename: upload.id, andHeaders: ["Content-Type":"application/offset+octet-stream", "Upload-Offset": upload.uploadOffset!, "Content-Length": String(chunks[position].count)])
          let task = TUSClient.shared.tusSession.session.uploadTask(with: request, from: chunks[position], completionHandler: { (data, response, error) in
             if let httpResponse = response as? HTTPURLResponse {
                 switch httpResponse.statusCode {
@@ -93,7 +93,7 @@ class TUSExecutor: NSObject, URLSessionDelegate {
                     if (httpResponse.statusCode == 204) {
                         TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "Chunk %u / %u complete", position + 1, chunks.count))
                         if (position + 1 == chunks.count) {
-                            TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "File %@ uploaded at %@", upload.id!, upload.uploadLocationURL!.absoluteString))
+                            TUSClient.shared.logger.log(forLevel: .Info, withMessage:String(format: "File %@ uploaded at %@", upload.id, upload.uploadLocationURL!.absoluteString))
                             TUSClient.shared.updateUpload(upload)
                             TUSClient.shared.delegate?.TUSSuccess(forUpload: upload)
                             TUSClient.shared.cleanUp(forUpload: upload)

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -27,11 +27,11 @@ public class TUSUpload: NSObject, NSCoding {
         id = coder.decodeObject(forKey:"id") as? String
         fileType = coder.decodeObject(forKey:"fileType") as? String
         filePath = coder.decodeObject(forKey:"filePath") as? URL
-        data = coder.decodeObject(forKey:"datas") as? Data
         uploadLocationURL = coder.decodeObject(forKey:"uploadLocationURL") as? URL
         contentLength = coder.decodeObject(forKey:"contentLength") as? String
         uploadLength = coder.decodeObject(forKey:"uploadLength") as? String
         uploadOffset = coder.decodeObject(forKey:"uploadOffset") as? String
+        data = coder.decodeObject(forKey: "data") as? Data
         status = TUSUploadStatus(rawValue: coder.decodeObject(forKey: "status") as! String)
     }
     

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -39,7 +39,7 @@ public class TUSUpload: NSObject, NSCoding {
     
     
     // MARK: Properties
-    var id: String
+    public let id: String
     var fileType: String? // TODO: Make sure only ".fileExtension" gets set. Current setup sets fileType as something like "1A1F31FE6-BB39-4A78-AECD-3C9BDE6D129E.jpeg"
     var filePath: URL?
     var data: Data?

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -24,20 +24,20 @@ public class TUSUpload: NSObject, NSCoding {
     
     public required init?(coder: NSCoder) {
         //
-        id = coder.decodeObject(forKey:"id") as? String
         fileType = coder.decodeObject(forKey:"fileType") as? String
         filePath = coder.decodeObject(forKey:"filePath") as? URL
         uploadLocationURL = coder.decodeObject(forKey:"uploadLocationURL") as? URL
         contentLength = coder.decodeObject(forKey:"contentLength") as? String
         uploadLength = coder.decodeObject(forKey:"uploadLength") as? String
         uploadOffset = coder.decodeObject(forKey:"uploadOffset") as? String
+        id = coder.decodeObject(forKey: "id") as! String
         data = coder.decodeObject(forKey: "data") as? Data
         status = TUSUploadStatus(rawValue: coder.decodeObject(forKey: "status") as! String)
     }
     
     
     // MARK: Properties
-    var id: String?
+    var id: String
     var fileType: String? // TODO: Make sure only ".fileExtension" gets set. Current setup sets fileType as something like "1A1F31FE6-BB39-4A78-AECD-3C9BDE6D129E.jpeg"
     var filePath: URL?
     var data: Data?
@@ -48,27 +48,32 @@ public class TUSUpload: NSObject, NSCoding {
     var status: TUSUploadStatus?
     
     public init(withId id: String, andFilePathString filePathString: String, andFileType fileType: String) {
-        super.init()
         self.id = id
         filePath = URL(string: filePathString)
         self.fileType = fileType
 
+        super.init()
     }
     
     public init(withId id: String, andFilePathURL filePathURL: URL, andFileType fileType: String) {
-        super.init()
         self.id = id
         filePath = filePathURL
         self.fileType = fileType
+
+        super.init()
     }
     
     public init(withId id: String, andData data: Data, andFileType fileType: String) {
         self.id = id
         self.data = data
         self.fileType = fileType
+        
+        super.init()
     }
     
     public init(withId id: String) {
         self.id = id
+        
+        super.init()
     }
 }

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -19,6 +19,7 @@ public class TUSUpload: NSObject, NSCoding {
         coder.encode(uploadLength, forKey: "uploadLength")
         coder.encode(uploadOffset, forKey: "uploadOffset")
         coder.encode(status?.rawValue, forKey: "status")
+        coder.encode(metadata, forKey: "metadata")
 
     }
     
@@ -33,6 +34,7 @@ public class TUSUpload: NSObject, NSCoding {
         id = coder.decodeObject(forKey: "id") as! String
         data = coder.decodeObject(forKey: "data") as? Data
         status = TUSUploadStatus(rawValue: coder.decodeObject(forKey: "status") as! String)
+        metadata = coder.decodeObject(forKey: "metadata") as! [String : String]
     }
     
     
@@ -46,6 +48,13 @@ public class TUSUpload: NSObject, NSCoding {
     var uploadLength: String?
     var uploadOffset: String?
     var status: TUSUploadStatus?
+    public var metadata: [String : String] = [:]
+    var encodedMetadata: String {
+        metadata["filename"] = id
+        return metadata.map { (key, value) in
+            "\(key) \(value.toBase64())"
+        }.joined(separator: ",")
+    }
     
     public init(withId id: String, andFilePathString filePathString: String, andFileType fileType: String) {
         self.id = id


### PR DESCRIPTION
This is to add support for custom Upload-Metadata headers inline with the Java client:

https://github.com/tus/tus-java-client/blob/master/src/main/java/io/tus/java/client/TusClient.java#L173
https://github.com/tus/tus-java-client/blob/master/src/main/java/io/tus/java/client/TusUpload.java#L101

The Java client doesn't seem to set a filename header but it was there for iOS so I have preserved that.

It is worth noting I haven't been able to get the example app working yet so PR is a bit in the dark (TUSKit compiles at least).