### PR TITLE
Add getStatus getter to TUSUpload

### DIFF
--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -101,4 +101,8 @@ public class TUSUpload: NSObject, NSCoding {
         
         super.init()
     }
+    
+    public func getStatus() -> TUSUploadStatus? {
+        return status
+    }
 }


### PR DESCRIPTION
I used a getter, instead of making the `status` public, as `status` is a var and shouldn't be changed from outside.