### PR TITLE
fix: don't use id as filename, but id + fileExtension

### DIFF
--- a/TUSKit/Classes/TUSClient.swift
+++ b/TUSKit/Classes/TUSClient.swift
@@ -106,7 +106,7 @@ public class TUSClient: NSObject, URLSessionTaskDelegate {
     ///   - upload: the upload object
     ///   - retries: number of retires to take if a call fails
     public func createOrResume(forUpload upload: TUSUpload, withRetries _: Int) {
-        let fileName = String(format: "%@%@", upload.id, upload.fileType!)
+        let fileName = upload.getUploadFilename()
 
         if fileManager.fileExists(withName: fileName) == false {
             logger.log(forLevel: .Info, withMessage: String(format: "File not found in local storage.", upload.id))
@@ -151,7 +151,7 @@ public class TUSClient: NSObject, URLSessionTaskDelegate {
                 logger.log(forLevel: .Info, withMessage: String(format: "File %@ has been previously been created", upload.id))
                 executor.uploadInBackground(upload: upload)
             case .new:
-                logger.log(forLevel: .Info, withMessage: String(format: "Creating file %@ on server", upload.id))
+                logger.log(forLevel: .Info, withMessage: String(format: "Creating file %@ on server", upload.getUploadFilename()))
                 upload.contentLength = "0"
                 upload.uploadOffset = "0"
                 upload.uploadLength = String(fileManager.sizeForLocalFilePath(filePath: String(format: "%@%@", fileManager.fileStorePath(), fileName)))

--- a/TUSKit/Classes/TUSExecutor.swift
+++ b/TUSKit/Classes/TUSExecutor.swift
@@ -40,13 +40,13 @@ class TUSExecutor: NSObject, URLSessionDelegate {
                                  andMethod: "POST",
                                  andContentLength: upload.contentLength,
                                  andUploadLength: upload.uploadLength,
-                                 andFilename: upload.id,
+                                 andFilename: upload.getUploadFilename(),
                                  andHeaders: ["Upload-Extension": "creation", "Upload-Metadata": upload.encodedMetadata])
 
         let task = TUSClient.shared.tusSession.session.dataTask(with: request) { _, response, _ in
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 201 {
-                    TUSClient.shared.logger.log(forLevel: .Info, withMessage: String(format: "File %@ created", upload.id))
+                    TUSClient.shared.logger.log(forLevel: .Info, withMessage: String(format: "File %@ created", upload.getUploadFilename()))
                     // Set the new status and other props for the upload
                     upload.status = .created
                     upload.uploadLocationURL = URL(string: httpResponse.allHeaderFieldsUpper()["LOCATION"]!, relativeTo: TUSClient.shared.uploadURL)
@@ -166,7 +166,7 @@ class TUSExecutor: NSObject, URLSessionDelegate {
         }
 
         
-        let request: URLRequest = urlRequest(withFullURL: upload.uploadLocationURL!, andMethod: "PATCH", andContentLength: upload.contentLength!, andUploadLength: nil, andFilename: upload.id, andHeaders: ["Content-Type": "application/offset+octet-stream", "Upload-Offset": upload.uploadOffset!, "Content-Length": String(chunks[position].count), "Upload-Metadata": upload.encodedMetadata])
+        let request: URLRequest = urlRequest(withFullURL: upload.uploadLocationURL!, andMethod: "PATCH", andContentLength: upload.contentLength!, andUploadLength: nil, andFilename: upload.getUploadFilename(), andHeaders: ["Content-Type": "application/offset+octet-stream", "Upload-Offset": upload.uploadOffset!, "Content-Length": String(chunks[position].count), "Upload-Metadata": upload.encodedMetadata])
 
         let task = TUSClient.shared.tusSession.session.uploadTask(with: request, from: chunks[position], completionHandler: { _, response, _ in
             if let httpResponse = response as? HTTPURLResponse {

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -66,7 +66,7 @@ public class TUSUpload: NSObject, NSCoding {
     var prevStatus: TUSUploadStatus?
     public var metadata: [String : String] = [:]
     var encodedMetadata: String {
-        metadata["filename"] = id
+        metadata["filename"] = getUploadFilename()
         return metadata.map { (key, value) in
             "\(key) \(value.toBase64())"
         }.joined(separator: ",")
@@ -104,5 +104,9 @@ public class TUSUpload: NSObject, NSCoding {
     
     public func getStatus() -> TUSUploadStatus? {
         return status
+    }
+    
+    public func getUploadFilename() -> String {
+        return String(format: "%@%@", self.id, self.fileType!)
     }
 }


### PR DESCRIPTION
This changes that on the TUS server the file is not created with its id, but with the id + file extensions. This has the advantage, that the TUS server will return the file with the correct extension, which some clients may rely on.

Also, our  TUS server implementation relies on the file extension as we need to process some files based on their file type.

I am not sure whether this is something that we wouldn't do in the "TUS ecosystem", however, I find that the android/java library does this also.
(As I am building a react native bridge (thus one lib for android & iOS) its great to have behaviour the same across platforms).