### PR TITLE
Fix: failed to copy file

### DIFF
--- a/TUSKit/Classes/TUSFileManager.swift
+++ b/TUSKit/Classes/TUSFileManager.swift
@@ -34,7 +34,7 @@ class TUSFileManager: NSObject {
 
     internal func copyFile(atLocation location: URL, withFileName name: String) -> Bool {
         do {
-            try FileManager.default.copyItem(at: location, to: URL(fileURLWithPath: fileStorePath().appending(name)))
+            try FileManager.default.copyItem(atPath: location.path, toPath: fileStorePath().appending(name))
             return true
         } catch let error as NSError {
             let response: TUSResponse = TUSResponse(message: "Failed moving file \(location.absoluteString) to \(fileStorePath().appending(name)) for TUS folder storage")


### PR DESCRIPTION
We started to see failures like these from `TUSFileManager.copyFile`:
```
The file XYZ.jpg couldn’t be opened because there is no such file. Error code = 260
```
Although the file exists.

This fixes the issue.