### PR TITLE
Implement custom dynamic headers, fix bug where background tasks never end in certain situations

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -13,7 +13,7 @@ PODS:
     - Nimble (~> 7.0)
   - Quick (1.2.0)
   - TLPhotoPicker (2.1.3)
-  - TUSKit (2.0.0)
+  - TUSKit (2.1.0)
 
 DEPENDENCIES:
   - AppSpectorSDK
@@ -44,7 +44,7 @@ SPEC CHECKSUMS:
   Nimble-Snapshots: f5459b5b091678dc942d03ec4741cacb58ba4a52
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   TLPhotoPicker: 2c4a20d62952bd368edbf44d18476f663a718ada
-  TUSKit: befb40e402aae1ee35a6b2b1edda26416bd0e473
+  TUSKit: 1a935c22c0719dee2f00d2767f01fcea63ae2aa0
 
 PODFILE CHECKSUM: 56e9b6c1fa8da25eda882f2eaba8707f765eb8e1
 

--- a/Example/TUSKit/ViewController.swift
+++ b/Example/TUSKit/ViewController.swift
@@ -64,7 +64,7 @@ class ViewController: UIViewController, TUSDelegate, UIImagePickerControllerDele
             let number = Int.random(in: 0 ..< 1000) //TODO: Remove before release: this is only set so we can run multiple files while developer
 
             //When you have a file, create an upload, and give it a Id.
-            let upload: TUSUpload = TUSUpload(withId:  String(number), andFilePathURL: file, andFileType: ".jpeg")
+            let upload: TUSUpload = TUSUpload(withId: String(number), andFilePathURL: file, andFileType: ".jpeg", andCustomDynamicHeaders: ["idInHeader": String(number)])
             upload.metadata = ["hello": "world"]
             //Create or resume upload
             TUSClient.shared.createOrResume(forUpload: upload, withCustomHeaders: ["Header": "Value"])

--- a/TUSKit/Classes/TUSExecutor.swift
+++ b/TUSKit/Classes/TUSExecutor.swift
@@ -214,9 +214,8 @@ class TUSExecutor: NSObject, URLSessionDelegate {
         if continueUploading() {
             let pendingUploads = TUSClient.shared.pendingUploads()
             TUSClient.shared.createOrResume(forUpload: pendingUploads[0])
-        } else {
-            completion(true)
         }
+        completion(true)
     }
 
     internal func cancel(forUpload upload: TUSUpload, error: Error?, failed: Bool = false) {

--- a/TUSKit/Classes/TUSUpload+isEqual.swift
+++ b/TUSKit/Classes/TUSUpload+isEqual.swift
@@ -16,7 +16,7 @@ extension TUSUpload {
                 && self.metadata == object.metadata
                 && self.status == object.getStatus()
                 && self.data == object.data
-            
+                && self.customDynamicHeaders == object.customDynamicHeaders
         }
         return false;
     }

--- a/TUSKit/Classes/TUSUpload.swift
+++ b/TUSKit/Classes/TUSUpload.swift
@@ -21,7 +21,7 @@ public class TUSUpload: NSObject, NSCoding {
         coder.encode(status?.rawValue, forKey: "status")
         coder.encode(prevStatus?.rawValue, forKey: "prevStatus")
         coder.encode(metadata, forKey: "metadata")
-
+        coder.encode(customDynamicHeaders, forKey: "customDynamicHeaders")
     }
     
     public required init?(coder: NSCoder) {
@@ -36,7 +36,7 @@ public class TUSUpload: NSObject, NSCoding {
         data = coder.decodeObject(forKey: "data") as? Data
         status = TUSUploadStatus(rawValue: coder.decodeObject(forKey: "status") as! String)
         metadata = coder.decodeObject(forKey: "metadata") as! [String : String]
-        
+        customDynamicHeaders = coder.decodeObject(forKey: "customDynamicHeaders") as! [String : String]
         // Migration safe: in previous versions this field did not exists so we set it in a safe manner
         let prevStatusString = coder.decodeObject(forKey: "prevStatus") as? String
         prevStatus = prevStatusString != nil ? TUSUploadStatus(rawValue: prevStatusString!) : nil
@@ -52,6 +52,7 @@ public class TUSUpload: NSObject, NSCoding {
     var contentLength: String?
     var uploadLength: String?
     var uploadOffset: String?
+    var customDynamicHeaders: [String : String] = [:]
     var status: TUSUploadStatus?{
         // When the status updates we want to update the previous status
         didSet {
@@ -72,32 +73,36 @@ public class TUSUpload: NSObject, NSCoding {
         }.joined(separator: ",")
     }
     
-    public init(withId id: String, andFilePathString filePathString: String, andFileType fileType: String) {
+    public init(withId id: String, andFilePathString filePathString: String, andFileType fileType: String, andCustomDynamicHeaders customHeaders: [String : String] = [:]) {
         self.id = id
         self.filePath = URL(fileURLWithPath: filePathString)
         self.fileType = fileType
+        self.customDynamicHeaders = customHeaders
 
         super.init()
     }
     
-    public init(withId id: String, andFilePathURL filePathURL: URL, andFileType fileType: String) {
+    public init(withId id: String, andFilePathURL filePathURL: URL, andFileType fileType: String, andCustomDynamicHeaders customHeaders: [String : String] = [:]) {
         self.id = id
         self.filePath = filePathURL
         self.fileType = fileType
+        self.customDynamicHeaders = customHeaders
 
         super.init()
     }
     
-    public init(withId id: String, andData data: Data, andFileType fileType: String) {
+    public init(withId id: String, andData data: Data, andFileType fileType: String, andCustomDynamicHeaders customHeaders: [String : String] = [:]) {
         self.id = id
         self.data = data
         self.fileType = fileType
+        self.customDynamicHeaders = customHeaders
         
         super.init()
     }
     
-    public init(withId id: String) {
+    public init(withId id: String, andCustomDynamicHeaders customHeaders: [String : String] = [:]) {
         self.id = id
+        self.customDynamicHeaders = customHeaders
         
         super.init()
     }


### PR DESCRIPTION
**Implement custom dynamic headers**
- Custom dynamic headers are added as TUSUpload init parameters
- Purpose is to enable different header for every file when multiple files are added to upload queue
- Existing custom headers when creating or resuming an upload are not adequate to be dynamic as they are saved in TUSExecutor which exists only as an instance in TUSClient singleton. The result is that only last set customHeader parameter is used

**Fix bug where background tasks never end in certain situations**
- When multiple uploads are in queue endBackgroundTask function is called only when last one finishes
- Result is that background tasks of first n-1 uploads are never ended