### PR TITLE
location as absolute url

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -79,7 +79,7 @@ final class TUSAPI {
                 let (_, response) = try result.get()
 
                 guard let location = response.allHeaderFields[caseInsensitive: "location"] as? String,
-                      let locationURL = URL(string: location) else {
+                      let locationURL = URL(string: location, relativeTo: metaData.uploadURL) else {
                     throw TUSAPIError.couldNotRetrieveLocation
                 }
 

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -54,7 +54,7 @@ final class TUSAPITests: XCTestCase {
     }
     
     func testCreation() throws {
-        let remoteFileURL = URL(string: "tus.io/myfile")!
+        let remoteFileURL = URL(string: "https://tus.io/myfile")!
         MockURLProtocol.prepareResponse(for: "POST") { _ in
             MockURLProtocol.Response(status: 200, headers: ["Location": remoteFileURL.absoluteString], data: nil)
         }


### PR DESCRIPTION
# Problem

According to the tus documentation the URL in the Location Header can be absolute or relative. But this lib can only handle if it's absolute.

> The Server MUST set the Location header to the URL of the created resource. This URL MAY be absolute or relative.
> -- https://tus.io/protocols/resumable-upload.html#post

The JS lib works correctly, as it will make an absolute url from the Location header.

https://github.com/tus/tus-js-client/blob/a43f6e9ca293617cae97994613434caea8788c2d/lib/upload.js#L961-L969

## Example
In this case where the Location header is set to a relative value, the upload will fail.
```
baseURL = "https://domain.com/api/upload"
Location = "/upload/generated-upload-id"
```
The PATCH request tries `/upload/generated-upload-id`, where is really should try `https://domain.com/api/upload/generated-upload-id`

This change will make it work correctly in the case above, and preserves the current functionality
```
baseURL = "https://domain.com/api/upload"
Location = "https://otherdomain.com/upload/generated-upload-id"
```
Will still send the PATCH requests to `https://otherdomain.com/upload/generated-upload-id`