### PR TITLE
Custom headers for real

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -183,20 +183,6 @@ final class TUSAPI {
         return task
     }
     
-    func makeUploadRequest(data: Data, location: URL) -> URLRequest {
-        let offset: Int = 0
-        let length: Int = data.count
-        
-        let headers = [
-            "Content-Type": "application/offset+octet-stream",
-            "Upload-Offset": String(offset),
-            "Content-Length": String(length)
-        ]
-
-        return makeRequest(url: location, method: .patch, headers: headers)
-        
-    }
-    
     /// A factory to make requests with sane defaults.
     /// - Parameters:
     ///   - url: The URL of the request.

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -92,25 +92,25 @@ final class TUSAPI {
     }
     
     func makeCreateRequest(metaData: UploadMetadata) -> URLRequest {
-        func makeUploadMetaHeaders() -> [String: String] {
-            let fileName = metaData.filePath.lastPathComponent
+        func makeUploadMetaHeader() -> [String: String] {
+            var metaDataDict: [String: String] = [:]
             
-            var metaDataHeaders: [String: String] = [:]
+            let fileName = metaData.filePath.lastPathComponent
             if !fileName.isEmpty && fileName != "/" { // A filename can be invalid, e.g. "/"
-                metaDataHeaders["filename"] = fileName
+                metaDataDict["filename"] = fileName
             }
             
             if let mimeType = metaData.mimeType, !mimeType.isEmpty {
-                metaDataHeaders["filetype"] = mimeType
+                metaDataDict["filetype"] = mimeType
             }
-            return metaDataHeaders
+            return metaDataDict
         }
        
         /// Turn dict into a comma separated base64 string
-        func encode(headers: [String: String]) -> String? {
-            guard !headers.isEmpty else { return nil }
+        func encode(_ dict: [String: String]) -> String? {
+            guard !dict.isEmpty else { return nil }
             var str = ""
-            for (key, value) in headers {
+            for (key, value) in dict {
                 let appendingStr: String
                 if !str.isEmpty {
                     str += ", "
@@ -121,19 +121,17 @@ final class TUSAPI {
             return str
         }
         
-        var headers = ["Upload-Extension": "creation",
-                       "Upload-Length": String(metaData.size)]
+        var defaultHeaders = ["Upload-Extension": "creation",
+                              "Upload-Length": String(metaData.size)]
         
-        let encoded = encode(headers: makeUploadMetaHeaders())
-        
-        if let encodedMetadata = encoded  {
-            headers["Upload-Metadata"] = encodedMetadata
+        if let encodedMetadata = encode(makeUploadMetaHeader())  {
+            defaultHeaders["Upload-Metadata"] = encodedMetadata
         }
         
         /// Attach all headers from customHeader property
-        let headersWithCustom = headers.merging(metaData.customHeaders ?? [:]) { _, new in new }
+        let headers = defaultHeaders.merging(metaData.customHeaders ?? [:]) { _, new in new }
         
-        return makeRequest(url: metaData.uploadURL, method: .post, headers: headersWithCustom)
+        return makeRequest(url: metaData.uploadURL, method: .post, headers: headers)
     }
     
     /// Uploads data

--- a/Sources/TUSKit/Tasks/UploadDataTask.swift
+++ b/Sources/TUSKit/Tasks/UploadDataTask.swift
@@ -90,7 +90,7 @@ final class UploadDataTask: NSObject, IdentifiableTask {
             return
         }
         
-        let task = api.upload(data: dataToUpload, range: range, location: remoteDestination) { [weak self] result in
+        let task = api.upload(data: dataToUpload, range: range, location: remoteDestination, metaData: self.metaData) { [weak self] result in
             self?.queue.async {
                 guard let self = self else { return }
                 // Getting rid of needing .self inside this closure

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -100,8 +100,12 @@ final class TUSAPITests: XCTestCase {
         let length = data.count
         let range = offset..<data.count
         let uploadExpectation = expectation(description: "Call api.upload()")
+        let metaData = UploadMetadata(id: UUID(),
+                                      filePath: URL(string: "file://whatever/abc")!,
+                                      uploadURL: URL(string: "io.tus")!,
+                                      size: length)
     
-        api.upload(data: Data(), range: range, location: uploadURL) { _ in
+        api.upload(data: Data(), range: range, location: uploadURL, metaData: metaData) { _ in
             uploadExpectation.fulfill()
         }
         

--- a/Tests/TUSKitTests/TUSClient/TUSClient_CustomHeadersTests.swift
+++ b/Tests/TUSKitTests/TUSClient/TUSClient_CustomHeadersTests.swift
@@ -44,8 +44,8 @@ final class TUSClient_CustomHeadersTests: XCTestCase {
         // Make sure client adds custom headers
         
         // Expected values
-        let key = "TUSKit"
-        let value = "TransloaditKit"
+        let key = "Authorization"
+        let value = "Bearer [token]"
         let customHeaders = [key: value]
         
         // Store file
@@ -70,11 +70,7 @@ final class TUSClient_CustomHeadersTests: XCTestCase {
         
         for request in createRequests {
             let headers = try XCTUnwrap(request.allHTTPHeaderFields)
-            let metaDataString = try XCTUnwrap(headers["Upload-Metadata"])
-            for (key, value) in customHeaders {
-                XCTAssert(metaDataString.contains(key), "Expected \(metaDataString) to contain \(key), headers are \(customHeaders)")
-                XCTAssert(metaDataString.contains(value.toBase64()), "Expected \(metaDataString) to contain base 64 value for \(value)")
-            }
+            XCTAssert(headers[key] == value, "Expected custom header '\(key)' to exist on headers with value: '\(value)'")
         }
     }
     


### PR DESCRIPTION
`customHeaders` property is merged into the Upload-Metadata header, as opposed them being attached directly on the request.

I think as it should've been before these changes: https://github.com/tus/TUSKit/commit/42179fb2598ca53bca890db9f1c2842df71e4d51#diff-c5b7f824014d07192bbcf8f4ec6c018b03e7b74d4a2e5d4e9f9b7ede0ad8a385L134

This PR makes sure custom headers are sent with the .patch request as well.
