### PR TITLE
Custom headers for status requests

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -42,10 +42,11 @@ final class TUSAPI {
     /// By retrieving the status,  we know where to continue when we upload again.
     /// - Parameters:
     ///   - remoteDestination: A URL to retrieve the status from (received from the create call)
+    ///   - headers: Request headers.
     ///   - completion: A completion giving us the `Status` of an upload.
     @discardableResult
-    func status(remoteDestination: URL, completion: @escaping (Result<Status, TUSAPIError>) -> Void) -> URLSessionDataTask {
-        let request = makeRequest(url: remoteDestination, method: .head, headers: [:])
+    func status(remoteDestination: URL, headers: [String: String]?, completion: @escaping (Result<Status, TUSAPIError>) -> Void) -> URLSessionDataTask {
+        let request = makeRequest(url: remoteDestination, method: .head, headers: headers ?? [:])
         let task = session.dataTask(request: request) { result in
             processResult(completion: completion) {
                 let (_, response) =  try result.get()

--- a/Sources/TUSKit/Tasks/StatusTask.swift
+++ b/Sources/TUSKit/Tasks/StatusTask.swift
@@ -36,7 +36,7 @@ final class StatusTask: IdentifiableTask {
     func run(completed: @escaping TaskCompletion) {
         // Improvement: On failure, try uploading from the start. Create creationtask.
         if didCancel { return }
-        sessionTask = api.status(remoteDestination: remoteDestination) { [weak self] result in
+        sessionTask = api.status(remoteDestination: remoteDestination, headers: self.metaData.customHeaders) { [weak self] result in
             guard let self = self else { return }
             // Getting rid of self. in this closure
             let metaData = self.metaData

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -39,7 +39,13 @@ final class TUSAPITests: XCTestCase {
         
         let statusExpectation = expectation(description: "Call api.status()")
         let remoteFileURL = URL(string: "https://tus.io/myfile")!
-        api.status(remoteDestination: remoteFileURL, completion: { result in
+        
+        let metaData = UploadMetadata(id: UUID(),
+                                              filePath: URL(string: "file://whatever/abc")!,
+                                              uploadURL: URL(string: "io.tus")!,
+                                              size: length)
+        
+        api.status(remoteDestination: remoteFileURL, headers:  metaData.customHeaders, completion: { result in
             do {
                 let values = try result.get()
                 XCTAssertEqual(length, values.length)


### PR DESCRIPTION
Adding to the work done in https://github.com/tus/TUSKit/pull/126 by @Zmetser, added headers to status requests.

Retrying a failed upload would always fail because custom headers were not being picked up and used in the request.

