### PR TITLE
Fix/progress for

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -94,7 +94,7 @@ final class TUSAPI {
     func makeCreateRequest(metaData: UploadMetadata) -> URLRequest {
         func makeUploadMetaHeader() -> [String: String] {
             var metaDataDict: [String: String] = [:]
-            
+             
             let fileName = metaData.filePath.lastPathComponent
             if !fileName.isEmpty && fileName != "/" { // A filename can be invalid, e.g. "/"
                 metaDataDict["filename"] = fileName
@@ -103,6 +103,10 @@ final class TUSAPI {
             if let mimeType = metaData.mimeType, !mimeType.isEmpty {
                 metaDataDict["filetype"] = mimeType
             }
+           
+            let context = (metaData.context ?? [:]) as [String:String]
+            metaDataDict.merge(context) { (first, _) in first }
+
             return metaDataDict
         }
        
@@ -113,7 +117,7 @@ final class TUSAPI {
             for (key, value) in dict {
                 let appendingStr: String
                 if !str.isEmpty {
-                    str += ", "
+                    str += ","
                 }
                 appendingStr = "\(key) \(value.toBase64())"
                 str = str + appendingStr
@@ -188,7 +192,7 @@ final class TUSAPI {
     ///   - headers: The headers to add to the request.
     /// - Returns: A new URLRequest to use in any TUS API call.
     private func makeRequest(url: URL, method: HTTPMethod, headers: [String: String]) -> URLRequest {
-        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 30)
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 60)
         request.httpMethod = method.rawValue
         request.addValue("1.0.0", forHTTPHeaderField: "TUS-Resumable")
         for header in headers {

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -593,7 +593,7 @@ extension TUSClient: ProgressDelegate {
     
     @available(iOS 11.0, macOS 10.13, *)
     func progressUpdatedFor(metaData: UploadMetadata, totalUploadedBytes: Int) {
-        /* delegate?.progressFor(id: metaData.id, context: metaData.context, bytesUploaded: totalUploadedBytes, totalBytes: metaData.size, client: self) */
+        delegate?.progressFor(id: metaData.id, context: metaData.context, bytesUploaded: totalUploadedBytes, totalBytes: metaData.size, client: self)
 
         /* var totalBytesUploaded: Int = 0 */
         /* var totalSize: Int = 0 */

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -591,16 +591,16 @@ extension TUSClient: ProgressDelegate {
     
     @available(iOS 11.0, macOS 10.13, *)
     func progressUpdatedFor(metaData: UploadMetadata, totalUploadedBytes: Int) {
-        delegate?.progressFor(id: metaData.id, context: metaData.context, bytesUploaded: totalUploadedBytes, totalBytes: metaData.size, client: self)
+        /* delegate?.progressFor(id: metaData.id, context: metaData.context, bytesUploaded: totalUploadedBytes, totalBytes: metaData.size, client: self) */
 
-        var totalBytesUploaded: Int = 0
-        var totalSize: Int = 0
-        for (_, metaData) in uploads {
-            totalBytesUploaded += metaData.uploadedRange?.count ?? 0
-            totalSize += metaData.size
-        }
+        /* var totalBytesUploaded: Int = 0 */
+        /* var totalSize: Int = 0 */
+        /* for (_, metaData) in uploads { */
+        /*     totalBytesUploaded += metaData.uploadedRange?.count ?? 0 */
+        /*     totalSize += metaData.size */
+        /* } */
 
-        delegate?.totalProgress(bytesUploaded: totalBytesUploaded, totalBytes: totalSize, client: self)
+        /* delegate?.totalProgress(bytesUploaded: totalBytesUploaded, totalBytes: totalSize, client: self) */
     }
 }
 

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -123,7 +123,7 @@ public final class TUSClient {
     /// Get which uploads aren't finished.
     public func getRemainingUploads() -> [(UUID, [String: String]?)] {
         let metaData = getStoredTasks()
-        return metadata.map { metaData in
+        return metaData.map { metaData in
             (metaData.id, metaData.context)   
         }
     }
@@ -400,7 +400,7 @@ public final class TUSClient {
     }
 
     /// Convert UUIDs into tasks.
-    private func scheduleStoredTasks(taskIds: [UUID]) => {
+    private func scheduleStoredTasks(taskIds: [UUID]) -> [UploadMetadata] {
         do {
             let metaDataItems = try files.loadAllMetadata().filter({ metaData in 
                 // Only allow specified uploads and errors are below an amount

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -173,10 +173,7 @@ public final class TUSClient {
         do {
             let id = UUID()
             let destinationFilePath = try files.copy(from: filePath, id: id)
-            delegate?.didInitializeUpload(id: id, context: context, client: self);
-            if(startNow) {
-              try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context)
-            }
+            try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context, startNow: startNow)
             return id
         } catch let error as TUSClientError {
             throw error
@@ -344,7 +341,7 @@ public final class TUSClient {
     
     /// Upload a file at the URL. Will not copy the path.
     /// - Parameter storedFilePath: The path where the file is stored for processing.
-    private func scheduleTask(for storedFilePath: URL, id: UUID, uploadURL: URL?, customHeaders: [String: String], context: [String: String]?) throws {
+    private func scheduleTask(for storedFilePath: URL, id: UUID, uploadURL: URL?, customHeaders: [String: String], context: [String: String]?, startTask: Bool = true) throws {
         let filePath = storedFilePath
         
         func getSize() throws -> Int {
@@ -376,8 +373,12 @@ public final class TUSClient {
         
         try store(metaData: metaData)
         trackUpload()
-        
-        scheduler.addTask(task: task)
+       
+        delegate?.didInitializeUpload(id: id, context: context, client: self);
+       
+        if (startTask) {
+          scheduler.addTask(task: task)
+        }
     }
     
     /// Store UploadMetadata to disk

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -115,9 +115,13 @@ public final class TUSClient {
     }
 
     /// Start specific remaining uploads from locally stored files.
-    public func start(taskIds: [UUID]) {
+    @discardableResult
+    public func start(taskIds: [UUID]) -> [(UUID, [String: String]?)] {
         didStopAndCancel = false
-        
+        let metaData = scheduleStoredTasks()
+        return metaData.map { metaData in
+            (metaData.id, metaData.context)
+        }
     }
 
     /// Get which uploads aren't finished.
@@ -386,6 +390,7 @@ public final class TUSClient {
     /// Check which uploads aren't finished and return them.
     private func getStoredTasks() -> [UploadMetadata] {
         do {
+            try files.makeDirectoryIfNeeded()
             let metaDataItems = try files.loadAllMetadata().filter({ metaData in
                 // Only allow uploads where errors are below an amount
                 metaData.errorCount <= retryCount && !metaData.isFinished

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -173,7 +173,7 @@ public final class TUSClient {
         do {
             let id = UUID()
             let destinationFilePath = try files.copy(from: filePath, id: id)
-            try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context, startNow: startNow)
+            try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context, startTask: startNow)
             return id
         } catch let error as TUSClientError {
             throw error

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -166,12 +166,14 @@ public final class TUSClient {
     /// - Returns: ANn id
     /// - Throws: TUSClientError
     @discardableResult
-    public func uploadFileAt(filePath: URL, uploadURL: URL? = nil, customHeaders: [String: String] = [:], context: [String: String]? = nil) throws -> UUID {
+    public func uploadFileAt(filePath: URL, uploadURL: URL? = nil, customHeaders: [String: String] = [:], context: [String: String]? = nil, startNow: Bool = true) throws -> UUID {
         didStopAndCancel = false
         do {
             let id = UUID()
             let destinationFilePath = try files.copy(from: filePath, id: id)
-            try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context)
+            if(startNow) {
+              try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context)
+            }
             return id
         } catch let error as TUSClientError {
             throw error

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -406,6 +406,16 @@ public final class TUSClient {
                 // Only allow specified uploads and errors are below an amount
                 metaData.errorCount <= retryCount && !metaData.isFinished && taskIds.contains( metaData.id )
             })
+           
+            for metaData in metaDataItems {
+                try scheduleTask(for: metaData)
+            }
+
+            return metaDataItems
+        } catch (let error) {
+            let tusError = TUSClientError.couldNotLoadData(underlyingError: error)
+            delegate?.fileError(error: tusError, client: self)
+            return []
         }
     }
 

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -13,6 +13,8 @@ import MobileCoreServices
 
 /// Implement this delegate to receive updates from the TUSClient
 public protocol TUSClientDelegate: AnyObject {
+    /// TUSClient initialized an upload
+    func didInitializeUpload(id: UUID, context: [String: String]?, client: TUSClient)
     /// TUSClient is starting an upload
     func didStartUpload(id: UUID, context: [String: String]?, client: TUSClient)
     /// `TUSClient` just finished an upload, returns the URL of the uploaded file.
@@ -171,6 +173,7 @@ public final class TUSClient {
         do {
             let id = UUID()
             let destinationFilePath = try files.copy(from: filePath, id: id)
+            delegate?.didInitializeUpload(id: id, context: context, client: self);
             if(startNow) {
               try scheduleTask(for: destinationFilePath, id: id, uploadURL: uploadURL, customHeaders: customHeaders, context: context)
             }

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -38,7 +38,7 @@ final class TUSAPITests: XCTestCase {
         }
         
         let statusExpectation = expectation(description: "Call api.status()")
-        let remoteFileURL = URL(string: "tus.io/myfile")!
+        let remoteFileURL = URL(string: "https://tus.io/myfile")!
         api.status(remoteDestination: remoteFileURL, completion: { result in
             do {
                 let values = try result.get()
@@ -53,7 +53,7 @@ final class TUSAPITests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
-    func testCreation() throws {
+    func testCreationWithAbsolutePath() throws {
         let remoteFileURL = URL(string: "https://tus.io/myfile")!
         MockURLProtocol.prepareResponse(for: "POST") { _ in
             MockURLProtocol.Response(status: 200, headers: ["Location": remoteFileURL.absoluteString], data: nil)
@@ -63,12 +63,51 @@ final class TUSAPITests: XCTestCase {
         let creationExpectation = expectation(description: "Call api.create()")
         let metaData = UploadMetadata(id: UUID(),
                                       filePath: URL(string: "file://whatever/abc")!,
-                                      uploadURL: URL(string: "io.tus")!,
+                                      uploadURL: URL(string: "https://io.tus")!,
                                       size: size)
         api.create(metaData: metaData) { result in
             do {
                 let url = try result.get()
                 XCTAssertEqual(url, remoteFileURL)
+                creationExpectation.fulfill()
+            } catch {
+                XCTFail("Expected to retrieve a URL for this test")
+            }
+        }
+        
+        waitForExpectations(timeout: 3, handler: nil)
+        
+        let headerFields = try XCTUnwrap(MockURLProtocol.receivedRequests.first?.allHTTPHeaderFields)
+        let expectedFileName = metaData.filePath.lastPathComponent.toBase64()
+        let expectedHeaders: [String: String] =
+            [
+                "TUS-Resumable": "1.0.0",
+                "Upload-Extension": "creation",
+                "Upload-Length": String(size),
+                "Upload-Metadata": "filename \(expectedFileName)"
+            ]
+        
+        XCTAssertEqual(expectedHeaders, headerFields)
+    }
+    
+    func testCreationWithRelativePath() throws {
+        let uploadURL = URL(string: "https://tus.example.org/files")!
+        let relativePath = "files/24e533e02ec3bc40c387f1a0e460e216"
+        let expectedURL = URL(string: "https://tus.example.org/files/24e533e02ec3bc40c387f1a0e460e216")!
+        MockURLProtocol.prepareResponse(for: "POST") { _ in
+            MockURLProtocol.Response(status: 200, headers: ["Location": relativePath], data: nil)
+        }
+        
+        let size = 300
+        let creationExpectation = expectation(description: "Call api.create()")
+        let metaData = UploadMetadata(id: UUID(),
+                                      filePath: URL(string: "file://whatever/abc")!,
+                                      uploadURL: uploadURL,
+                                      size: size)
+        api.create(metaData: metaData) { result in
+            do {
+                let url = try result.get()
+                XCTAssertEqual(url.absoluteURL, expectedURL)
                 creationExpectation.fulfill()
             } catch {
                 XCTFail("Expected to retrieve a URL for this test")
@@ -101,9 +140,10 @@ final class TUSAPITests: XCTestCase {
         let range = offset..<data.count
         let uploadExpectation = expectation(description: "Call api.upload()")
     
-        api.upload(data: Data(), range: range, location: uploadURL) { _ in
+        let task = api.upload(data: Data(), range: range, location: uploadURL) { _ in
             uploadExpectation.fulfill()
         }
+        XCTAssertEqual(task.originalRequest?.url, uploadURL)
         
         waitForExpectations(timeout: 3, handler: nil)
         
@@ -118,4 +158,39 @@ final class TUSAPITests: XCTestCase {
         
         XCTAssertEqual(headerFields, expectedHeaders)
     }
+    
+    func testUploadWithRelativePath() throws {
+        let data = Data("Hello how are you".utf8)
+        let baseURL = URL(string: "https://tus.example.org/files")!
+        let relativePath = "files/24e533e02ec3bc40c387f1a0e460e216"
+        let uploadURL = URL(string: relativePath, relativeTo: baseURL)!
+        let expectedURL = URL(string: "https://tus.example.org/files/24e533e02ec3bc40c387f1a0e460e216")!
+        MockURLProtocol.prepareResponse(for: "PATCH") { _ in
+            MockURLProtocol.Response(status: 200, headers: ["Upload-Offset": String(data.count)], data: nil)
+        }
+        
+        let offset = 2
+        let length = data.count
+        let range = offset..<data.count
+        let uploadExpectation = expectation(description: "Call api.upload()")
+    
+        let task = api.upload(data: Data(), range: range, location: uploadURL) { _ in
+            uploadExpectation.fulfill()
+        }
+        XCTAssertEqual(task.originalRequest?.url, expectedURL)
+        
+        waitForExpectations(timeout: 3, handler: nil)
+        
+        let headerFields = try XCTUnwrap(MockURLProtocol.receivedRequests.first?.allHTTPHeaderFields)
+        let expectedHeaders: [String: String] =
+            [
+                "TUS-Resumable": "1.0.0",
+                "Content-Type": "application/offset+octet-stream",
+                "Upload-Offset": String(offset),
+                "Content-Length": String(length)
+            ]
+        
+        XCTAssertEqual(headerFields, expectedHeaders)
+    }
+    
 }


### PR DESCRIPTION
`totalProgress` is the event that causes the heap corruption / bad pointer access.
In my testing `progressFor` has not caused me any issues so I reenabled it in order to display progress for individual files again.