### PR TITLE
Add the ability to disable the creation extension on the client

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -33,9 +33,11 @@ final class TUSAPI {
     }
     
     let session: URLSession
-    
-    init(session: URLSession) {
+	let supportedExtensions: [TUSProtocolExtension]
+
+	init(session: URLSession, supportedExtensions: [TUSProtocolExtension]) {
         self.session = session
+		self.supportedExtensions = supportedExtensions
     }
     
     /// Fetch the status of an upload if an upload is not finished (e.g. interrupted).
@@ -122,8 +124,11 @@ final class TUSAPI {
             return str
         }
         
-        var defaultHeaders = ["Upload-Extension": "creation",
-                              "Upload-Length": String(metaData.size)]
+        var defaultHeaders = ["Upload-Length": String(metaData.size)]
+
+		if supportedExtensions.contains(.creation) {
+			defaultHeaders["Upload-Extension"] = "creation"
+		}
         
         if let encodedMetadata = encode(makeUploadMetaHeader())  {
             defaultHeaders["Upload-Metadata"] = encodedMetadata

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -33,11 +33,9 @@ final class TUSAPI {
     }
     
     let session: URLSession
-	let supportedExtensions: [TUSProtocolExtension]
 
-	init(session: URLSession, supportedExtensions: [TUSProtocolExtension]) {
+	init(session: URLSession) {
         self.session = session
-		self.supportedExtensions = supportedExtensions
     }
     
     /// Fetch the status of an upload if an upload is not finished (e.g. interrupted).
@@ -126,9 +124,7 @@ final class TUSAPI {
         
         var defaultHeaders = ["Upload-Length": String(metaData.size)]
 
-		if supportedExtensions.contains(.creation) {
-			defaultHeaders["Upload-Extension"] = "creation"
-		}
+		defaultHeaders["Upload-Extension"] = "creation"
         
         if let encodedMetadata = encode(makeUploadMetaHeader())  {
             defaultHeaders["Upload-Metadata"] = encodedMetadata

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -122,9 +122,8 @@ final class TUSAPI {
             return str
         }
         
-        var defaultHeaders = ["Upload-Length": String(metaData.size)]
-
-        defaultHeaders["Upload-Extension"] = "creation"
+        var defaultHeaders = ["Upload-Extension": "creation",
+                              "Upload-Length": String(metaData.size)]
         
         if let encodedMetadata = encode(makeUploadMetaHeader())  {
             defaultHeaders["Upload-Metadata"] = encodedMetadata

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -34,7 +34,7 @@ final class TUSAPI {
     
     let session: URLSession
 
-	init(session: URLSession) {
+    init(session: URLSession) {
         self.session = session
     }
     
@@ -124,7 +124,7 @@ final class TUSAPI {
         
         var defaultHeaders = ["Upload-Length": String(metaData.size)]
 
-		defaultHeaders["Upload-Extension"] = "creation"
+        defaultHeaders["Upload-Extension"] = "creation"
         
         if let encodedMetadata = encode(makeUploadMetaHeader())  {
             defaultHeaders["Upload-Metadata"] = encodedMetadata

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -59,6 +59,7 @@ public final class TUSClient {
     }
     public let sessionIdentifier: String
     public weak var delegate: TUSClientDelegate?
+	public var supportsCreation: Bool = false
     
     // MARK: - Private Properties
     
@@ -337,7 +338,14 @@ public final class TUSClient {
         func makeMetadata() throws -> UploadMetadata {
             let size = try getSize()
             let url = uploadURL ?? serverURL
-            return UploadMetadata(id: id, filePath: filePath, uploadURL: url, size: size, customHeaders: customHeaders, mimeType: filePath.mimeType.nonEmpty, context: context)
+
+			let metadata = UploadMetadata(id: id, filePath: filePath, uploadURL: url, size: size, customHeaders: customHeaders, mimeType: filePath.mimeType.nonEmpty, context: context)
+
+			if !supportsCreation {
+				metadata.remoteDestination = url
+			}
+
+            return metadata
         }
         
         let metaData = try makeMetadata()

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -93,7 +93,7 @@ public final class TUSClient {
     /// - Throws: File related errors when it can't make a directory at the designated path.
 	public init(server: URL, sessionIdentifier: String, storageDirectory: URL? = nil, session: URLSession = URLSession.shared, chunkSize: Int = 500 * 1024, supportedExtensions: [TUSProtocolExtension] = [.creation]) throws {
         self.sessionIdentifier = sessionIdentifier
-        self.api = TUSAPI(session: session, supportedExtensions: supportedExtensions)
+        self.api = TUSAPI(session: session)
         self.files = try Files(storageDirectory: storageDirectory)
         self.serverURL = server
         self.chunkSize = chunkSize

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -59,7 +59,7 @@ public final class TUSClient {
     }
     public let sessionIdentifier: String
     public weak var delegate: TUSClientDelegate?
-	public let supportedExtensions: [TUSProtocolExtension]
+    public let supportedExtensions: [TUSProtocolExtension]
     
     // MARK: - Private Properties
     
@@ -91,13 +91,13 @@ public final class TUSClient {
     ///   - session: A URLSession you'd like to use. Will default to `URLSession.shared`.
     ///   - chunkSize: The amount of bytes the data to upload will be chunked by. Defaults to 512 kB.
     /// - Throws: File related errors when it can't make a directory at the designated path.
-	public init(server: URL, sessionIdentifier: String, storageDirectory: URL? = nil, session: URLSession = URLSession.shared, chunkSize: Int = 500 * 1024, supportedExtensions: [TUSProtocolExtension] = [.creation]) throws {
+    public init(server: URL, sessionIdentifier: String, storageDirectory: URL? = nil, session: URLSession = URLSession.shared, chunkSize: Int = 500 * 1024, supportedExtensions: [TUSProtocolExtension] = [.creation]) throws {
         self.sessionIdentifier = sessionIdentifier
         self.api = TUSAPI(session: session)
         self.files = try Files(storageDirectory: storageDirectory)
         self.serverURL = server
         self.chunkSize = chunkSize
-		self.supportedExtensions = supportedExtensions
+        self.supportedExtensions = supportedExtensions
         scheduler.delegate = self
         removeFinishedUploads()
     }
@@ -335,19 +335,19 @@ public final class TUSClient {
             return size
         }
         
-		func makeMetadata() throws -> UploadMetadata {
-			let size = try getSize()
-			let url = uploadURL ?? serverURL
+        func makeMetadata() throws -> UploadMetadata {
+            let size = try getSize()
+            let url = uploadURL ?? serverURL
 
-			let metadata = UploadMetadata(id: id, filePath: filePath, uploadURL: url, size: size, customHeaders: customHeaders, mimeType: filePath.mimeType.nonEmpty, context: context)
+            let metadata = UploadMetadata(id: id, filePath: filePath, uploadURL: url, size: size, customHeaders: customHeaders, mimeType: filePath.mimeType.nonEmpty, context: context)
 
-			// If Creation isn't supported, we will use the provided url as the upload destination and assume the file has already been created by the server
-			if !supportedExtensions.contains(.creation) {
-				metadata.remoteDestination = url
-			}
+            // If Creation isn't supported, we will use the provided url as the upload destination and assume the file has already been created by the server
+            if !supportedExtensions.contains(.creation) {
+                metadata.remoteDestination = url
+            }
 
-			return metadata
-		}
+            return metadata
+        }
         
         let metaData = try makeMetadata()
         

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -59,7 +59,7 @@ public final class TUSClient {
     }
     public let sessionIdentifier: String
     public weak var delegate: TUSClientDelegate?
-	public var supportsCreation: Bool = false
+	public let supportedExtensions: [TUSProtocolExtension]
     
     // MARK: - Private Properties
     
@@ -91,13 +91,13 @@ public final class TUSClient {
     ///   - session: A URLSession you'd like to use. Will default to `URLSession.shared`.
     ///   - chunkSize: The amount of bytes the data to upload will be chunked by. Defaults to 512 kB.
     /// - Throws: File related errors when it can't make a directory at the designated path.
-    public init(server: URL, sessionIdentifier: String, storageDirectory: URL? = nil, session: URLSession = URLSession.shared, chunkSize: Int = 500 * 1024) throws {
+	public init(server: URL, sessionIdentifier: String, storageDirectory: URL? = nil, session: URLSession = URLSession.shared, chunkSize: Int = 500 * 1024, supportedExtensions: [TUSProtocolExtension] = [.creation]) throws {
         self.sessionIdentifier = sessionIdentifier
-        self.api = TUSAPI(session: session)
+        self.api = TUSAPI(session: session, supportedExtensions: supportedExtensions)
         self.files = try Files(storageDirectory: storageDirectory)
         self.serverURL = server
         self.chunkSize = chunkSize
-        
+		self.supportedExtensions = supportedExtensions
         scheduler.delegate = self
         removeFinishedUploads()
     }
@@ -335,18 +335,19 @@ public final class TUSClient {
             return size
         }
         
-        func makeMetadata() throws -> UploadMetadata {
-            let size = try getSize()
-            let url = uploadURL ?? serverURL
+		func makeMetadata() throws -> UploadMetadata {
+			let size = try getSize()
+			let url = uploadURL ?? serverURL
 
 			let metadata = UploadMetadata(id: id, filePath: filePath, uploadURL: url, size: size, customHeaders: customHeaders, mimeType: filePath.mimeType.nonEmpty, context: context)
 
-			if !supportsCreation {
+			// If Creation isn't supported, we will use the provided url as the upload destination and assume the file has already been created by the server
+			if !supportedExtensions.contains(.creation) {
 				metadata.remoteDestination = url
 			}
 
-            return metadata
-        }
+			return metadata
+		}
         
         let metaData = try makeMetadata()
         

--- a/Sources/TUSKit/TUSProtocolExtension.swift
+++ b/Sources/TUSKit/TUSProtocolExtension.swift
@@ -7,8 +7,6 @@
 
 public enum TUSProtocolExtension {
     case creation
-
-    static let all: [TUSProtocolExtension] = [.creation]
 }
 
 extension Array where Element == TUSProtocolExtension {

--- a/Sources/TUSKit/TUSProtocolExtension.swift
+++ b/Sources/TUSKit/TUSProtocolExtension.swift
@@ -6,12 +6,12 @@
 //
 
 public enum TUSProtocolExtension {
-	case creation
+    case creation
 
-	static let all: [TUSProtocolExtension] = [.creation]
+    static let all: [TUSProtocolExtension] = [.creation]
 }
 
 extension Array where Element == TUSProtocolExtension {
-	public static let all: [TUSProtocolExtension] = [.creation]
+    public static let all: [TUSProtocolExtension] = [.creation]
 }
 

--- a/Sources/TUSKit/TUSProtocolExtension.swift
+++ b/Sources/TUSKit/TUSProtocolExtension.swift
@@ -1,0 +1,17 @@
+//
+//  TUSProtocolExtension.swift
+//
+//
+//  Created by Brad Patras on 7/14/22.
+//
+
+public enum TUSProtocolExtension {
+	case creation
+
+	static let all: [TUSProtocolExtension] = [.creation]
+}
+
+extension Array where Element == TUSProtocolExtension {
+	public static let all: [TUSProtocolExtension] = [.creation]
+}
+

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -22,7 +22,7 @@ final class TUSAPITests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         let session = URLSession.init(configuration: configuration)
         uploadURL = URL(string: "www.tus.io")!
-		api = TUSAPI(session: session)
+        api = TUSAPI(session: session)
     }
     
     override func tearDown() {

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -22,7 +22,7 @@ final class TUSAPITests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         let session = URLSession.init(configuration: configuration)
         uploadURL = URL(string: "www.tus.io")!
-		api = TUSAPI(session: session, supportedExtensions: .all)
+		api = TUSAPI(session: session)
     }
     
     override func tearDown() {

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -22,7 +22,7 @@ final class TUSAPITests: XCTestCase {
         configuration.protocolClasses = [MockURLProtocol.self]
         let session = URLSession.init(configuration: configuration)
         uploadURL = URL(string: "www.tus.io")!
-        api = TUSAPI(session: session)
+		api = TUSAPI(session: session, supportedExtensions: .all)
     }
     
     override func tearDown() {


### PR DESCRIPTION
The TUS protocol specifies that the Creation step is an optional extension of the core protocol, so the TUSKit library shouldn't assume that servers supports it. Currently if a server doesn't support creation, the TUSKit client will fail to upload completely.  Ideally the TUSKit library should check the server for supported extensions via an `OPTIONS` request like mentioned in the [protocol docs](https://tus.io/protocols/resumable-upload.html#core-protocol).  To bridge this issue in the short term, I think the user should be able to specify which extensions the TUSKit client should use. (Creation is currently the only extension that I saw implemented in the TUSKit client)

There's more discussion on this topic in issue #134. 

An example of a server that supports the Core TUS protocol but not the Creation extension is [Vimeo's video upload api](https://developer.vimeo.com/api/upload/videos) (as of api version 3.4).

My quick fix proposal is to include `supportedExtensions: [TUSProtocolExtension] = [.creation]` to the TUSClient parameters.  Having the default be `[.creation]` prevents breaking any current usages.