### PR TITLE
Removed whitespace after comma

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -119,7 +119,7 @@ final class TUSAPI {
             for (key, value) in dict {
                 let appendingStr: String
                 if !str.isEmpty {
-                    str += ", "
+                    str += ","
                 }
                 appendingStr = "\(key) \(value.toBase64())"
                 str = str + appendingStr


### PR DESCRIPTION
Removes whitespace after comma when dictionary is converted to comma separated base64 string