### PR TITLE
bugfix for retry failing on subsequent launch

### DIFF
--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -337,7 +337,7 @@ public final class TUSClient {
     @discardableResult
     public func retry(id: UUID) throws -> Bool {
         do {
-            guard uploads[id] != nil else { return false }
+            guard uploads[id] == nil else { return false }
             guard let metaData = try files.findMetadata(id: id) else {
                 return false
             }


### PR DESCRIPTION
Hello, we are using TUSKit in our app and have encountered a problem with retry. 

We are using version 3.2.0 (or rather latest `main`, 3.2.0 has a compile error which was fixed in main)

STR:
- have a file fail to upload (using the wrong upload url is useful)
- close application and relaunch
- on launch, get `.failedUploadIDs()` and iterate over them calling `.retry(id)`
Expected: TusClient attempts the upload again
Actual: retry returns `false` because `uploads[id]` is `nil`

I see this reverts a recent change: https://github.com/tus/TUSKit/commit/2ad3209400c22d1c8760156d4a4168a44ad064e3 so perhaps this is not the correct solution, however I have tested with this change and it works both when retrying during the same session, and after closing and relaunching. 

