### PR TITLE
Separate out resuming and retrying uploads

### DIFF
--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -332,12 +332,15 @@ public final class TUSClient {
     /// Retry a failed upload. Note that `TUSClient` already has an internal retry mechanic before it reports an upload as failure.
     /// If however, you like to retry an upload at a later stage, you can use this method to trigger the upload again.
     /// - Parameter id: The id of an upload. Received when starting an upload, or via the `TUSClientDelegate`.
-    /// - Returns: True if the id is found. False if it's not found
+    /// - Returns: False if the id is found. True if it's not found
     /// - Throws: `TUSClientError.couldNotRetryUpload` if it can't load an the file. Or file related errors.
     @discardableResult
     public func retry(id: UUID) throws -> Bool {
         do {
-            guard uploads[id] != nil else { return false }
+            guard uploads[id] == nil else {
+              return false
+            }
+          
             guard let metaData = try files.findMetadata(id: id) else {
                 return false
             }
@@ -352,6 +355,29 @@ public final class TUSClient {
             throw TUSClientError.couldNotRetryUpload
         }
     }
+  
+  /// Resumes a paused upload.
+  /// - Parameter id: The id of an upload. Received when starting an upload, or via the `TUSClientDelegate`.
+  /// - Returns: True if the id is found and the upload was resumed. False if it's not found
+  /// - Throws: `TUSClientError.couldNotResumeUpload` if it can't load an the file. Or file related errors.
+  @discardableResult
+  public func resume(id: UUID) throws -> Bool {
+      do {
+          guard uploads[id] != nil else { return false }
+          guard let metaData = try files.findMetadata(id: id) else {
+              return false
+          }
+          
+          metaData.errorCount = 0
+          
+          try scheduleTask(for: metaData)
+          return true
+      } catch let error as TUSClientError {
+          throw error
+      } catch {
+          throw TUSClientError.couldNotResumeUpload
+      }
+  }
     
     // MARK: - Background uploads
     

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -332,7 +332,7 @@ public final class TUSClient {
     /// Retry a failed upload. Note that `TUSClient` already has an internal retry mechanic before it reports an upload as failure.
     /// If however, you like to retry an upload at a later stage, you can use this method to trigger the upload again.
     /// - Parameter id: The id of an upload. Received when starting an upload, or via the `TUSClientDelegate`.
-    /// - Returns: False if the id is found. True if it's not found
+    /// - Returns: True if the upload has been scheduled for a new upload attempt. False if the upload id does not correspond to a failed upload. Note that a paused upload should be resumed with `resume(id:)` rather than retried.
     /// - Throws: `TUSClientError.couldNotRetryUpload` if it can't load an the file. Or file related errors.
     @discardableResult
     public func retry(id: UUID) throws -> Bool {
@@ -358,7 +358,7 @@ public final class TUSClient {
   
   /// Resumes a paused upload.
   /// - Parameter id: The id of an upload. Received when starting an upload, or via the `TUSClientDelegate`.
-  /// - Returns: True if the id is found and the upload was resumed. False if it's not found
+  /// - Returns: True if the upload has been resumed. False if the upload id was not found or does not correspond to a paused upload.
   /// - Throws: `TUSClientError.couldNotResumeUpload` if it can't load an the file. Or file related errors.
   @discardableResult
   public func resume(id: UUID) throws -> Bool {

--- a/Sources/TUSKit/TUSClientError.swift
+++ b/Sources/TUSKit/TUSClientError.swift
@@ -15,6 +15,7 @@ public enum TUSClientError: Error {
     case couldNotDeleteFile(underlyingError: Error)
     case uploadIsAlreadyFinished
     case couldNotRetryUpload
+    case couldNotResumeUpload
     case couldnotRemoveFinishedUploads(underlyingError: Error)
     case receivedUnexpectedOffset
     case missingRemoteDestination

--- a/TUSKitExample/TUSKitExample.xcodeproj/project.pbxproj
+++ b/TUSKitExample/TUSKitExample.xcodeproj/project.pbxproj
@@ -113,7 +113,9 @@
 				2EB914B126F09F7800548562 /* Frameworks */,
 				2EB914B626F0A29E00548562 /* TUSKit */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		2EB9147A26F09D7600548562 /* Products */ = {
 			isa = PBXGroup;

--- a/TUSKitExample/TUSKitExample/Helpers/TUSWrapper.swift
+++ b/TUSKitExample/TUSKitExample/Helpers/TUSWrapper.swift
@@ -40,7 +40,7 @@ class TUSWrapper: ObservableObject {
     
     @MainActor
     func resumeUpload(id: UUID) {
-        _ = try? client.retry(id: id)
+        _ = try? client.resume(id: id)
         
         if case let .paused(bytesUploaded, totalBytes) = uploads[id] {
             withAnimation {


### PR DESCRIPTION
#169 flagged an issue with retrying failed uploads. This PR reverted a bugfix that was implemented to allow for resuming of paused uploads.

Since this function depends on whether an existing upload exists or not, and we want to have this check for semantic purposes, a second method is introduced in this PR to have separate retry and resume methods.

An alternative to consider is to not have a semantic split and just not check whether an upload id exists and always going straight for the metadata lookup.