### PR TITLE
Fix didStartUpload delegate method not being called

### DIFF
--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -631,8 +631,9 @@ extension TUSClient: SchedulerDelegate {
     
     func didStartTask(task: ScheduledTask, scheduler: Scheduler) {
         guard let task = task as? UploadDataTask else { return }
+        let isUploadRangeEmpty = task.metaData.uploadedRange?.isEmpty ?? true
         
-        if task.metaData.uploadedRange == nil && task.metaData.errorCount == 0 {
+        if isUploadRangeEmpty && task.metaData.errorCount == 0 {
             delegate?.didStartUpload(id: task.metaData.id, context: task.metaData.context, client: self)
         }
     }


### PR DESCRIPTION
Noticed the problem when I was implementing analytics in my project. 
`didStartUpload` is not being called because metadata `uploadedRange` is not nil after [StatusTask is done](https://github.com/tus/TUSKit/blob/57cb4d6b67ab21369a5e6cc84ff9b7c7e9321f26/Sources/TUSKit/Tasks/StatusTask.swift#L60C31-L60C31).