### PR TITLE
Fix/api memory leak

### DIFF
--- a/Tests/TUSKitTests/Support/Support.swift
+++ b/Tests/TUSKitTests/Support/Support.swift
@@ -39,8 +39,8 @@ func makeClient(storagePath: URL?, supportedExtensions: [TUSProtocolExtension] =
     do {
         let client = try TUSClient(server: liveDemoPath,
                                    sessionIdentifier: "TEST",
+                                   sessionConfiguration: configuration,
                                    storageDirectory: storagePath,
-                                   session: URLSession.init(configuration: configuration),
                                    supportedExtensions: supportedExtensions)
         return client
     } catch {

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -20,9 +20,8 @@ final class TUSAPITests: XCTestCase {
         
         let configuration = URLSessionConfiguration.default
         configuration.protocolClasses = [MockURLProtocol.self]
-        let session = URLSession.init(configuration: configuration)
         uploadURL = URL(string: "www.tus.io")!
-        api = TUSAPI(session: session)
+        api = TUSAPI(sessionConfiguration: configuration)
     }
     
     override func tearDown() {

--- a/Tests/TUSKitTests/TUSClient/TUSClientInternalTests.swift
+++ b/Tests/TUSKitTests/TUSClient/TUSClientInternalTests.swift
@@ -60,7 +60,7 @@ final class TUSClientInternalTests: XCTestCase {
     }
         
     
-    func testClientDoesNotDeleteUploadedFilesOnStartup() throws {
+    func testClientDoesNotRemoveUnfinishedUploadsOnStartup() throws {
         var contents = try FileManager.default.contentsOfDirectory(at: fullStoragePath, includingPropertiesForKeys: nil)
         XCTAssert(contents.isEmpty)
         
@@ -71,10 +71,10 @@ final class TUSClientInternalTests: XCTestCase {
         
         client = makeClient(storagePath: fullStoragePath)
         contents = try FileManager.default.contentsOfDirectory(at: fullStoragePath, includingPropertiesForKeys: nil)
-        XCTAssertFalse(contents.isEmpty, "Expected client to NOT clear unfinished uploaded metadata")
+        XCTAssertFalse(contents.isEmpty, "The client is expected to NOT remove unfinished uploads on startup")
     }
     
-    func testClientDeletesUploadedFilesOnStartup() throws {
+    func testClientDoesNotRemoveFinishedUploadsOnStartup() throws {
         var contents = try FileManager.default.contentsOfDirectory(at: fullStoragePath, includingPropertiesForKeys: nil)
         XCTAssert(contents.isEmpty)
         
@@ -87,6 +87,6 @@ final class TUSClientInternalTests: XCTestCase {
         
         client = makeClient(storagePath: fullStoragePath)
         contents = try FileManager.default.contentsOfDirectory(at: fullStoragePath, includingPropertiesForKeys: nil)
-        XCTAssert(contents.isEmpty, "Expected client to clear finished uploaded metadata")
+        XCTAssertFalse(contents.isEmpty, "The client is expected to NOT remove finished uploads on startup")
     }
 }

--- a/Tests/TUSKitTests/TUSClient/TUSClient_CacheTests.swift
+++ b/Tests/TUSKitTests/TUSClient/TUSClient_CacheTests.swift
@@ -93,6 +93,8 @@ final class TUSClient_CacheTests: XCTestCase {
         let storagePath = URL(string: "DELETE_ME")!
         let docDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let fullStoragePath = docDir.appendingPathComponent(storagePath.absoluteString)
+        
+        clearDirectory(dir: fullStoragePath)
 
         client = makeClient(storagePath: storagePath)
         tusDelegate = TUSMockDelegate()


### PR DESCRIPTION
Hey, @donnywals!

This PR fixes a memory leak in `TUSAPI` and makes tests green.

Tests now use a new initializer with `sessionConfiguration` to initialize `TUSClient`. Also, due to changes in the logic of this initializer, the `testClientDeletesUploadedFilesOnStartup` test was replaced with a new one.

If necessary, I can split the memory leak fix and test changes into two separate pull requests.

Please take a look and let me know what your thoughts are on this matter.