### PR TITLE
Fixed force unwrap causing crashes when write fails (issue #194)

### DIFF
--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -152,7 +152,7 @@ final class Files {
             
             let targetLocation = storageDirectory.appendingPathComponent(fileName)
             
-            try! data.write(to: targetLocation, options: .atomic)
+            try data.write(to: targetLocation, options: .atomic)
             return targetLocation
         }
     }


### PR DESCRIPTION
Removed force unwrap on write that causes a crash in case of error ( #194 ).
The method is already throwing so it doesn't require any other changes.