### PR TITLE
Provide response body to failed request errors

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -14,7 +14,7 @@ public enum TUSAPIError: Error, LocalizedError {
     case couldNotFetchServerInfo
     case couldNotRetrieveOffset
     case couldNotRetrieveLocation
-    case failedRequest(HTTPURLResponse, data: Data?)
+    case failedRequest(HTTPURLResponse, Data?)
 
     public var localizedDescription: String {
         switch self {
@@ -149,7 +149,7 @@ final class TUSAPI {
                     let (data, response) =  try result.get()
 
                     guard (200...299).contains(response.statusCode) else {
-                        throw TUSAPIError.failedRequest(response, data: data)
+                        throw TUSAPIError.failedRequest(response, data)
                     }
                     
                     guard let lengthStr = response.allHeaderFields[caseInsensitive: "upload-Length"] as? String,
@@ -188,7 +188,7 @@ final class TUSAPI {
                     let (data, response) = try result.get()
 
                     guard (200...299).contains(response.statusCode) else {
-                        throw TUSAPIError.failedRequest(response, data: data)
+                        throw TUSAPIError.failedRequest(response, data)
                     }
 
                     guard let location = response.allHeaderFields[caseInsensitive: "location"] as? String,
@@ -293,7 +293,7 @@ final class TUSAPI {
                     let (data, response) = try result.get()
 
                     guard (200...299).contains(response.statusCode) else {
-                        throw TUSAPIError.failedRequest(response, data: data)
+                        throw TUSAPIError.failedRequest(response, data)
                     }
                     
                     guard let offsetStr = response.allHeaderFields[caseInsensitive: "upload-offset"] as? String,

--- a/Sources/TUSKit/TUSClientError.swift
+++ b/Sources/TUSKit/TUSClientError.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 /// The errors that are passed from TUSClient
-public enum TUSClientError: Error {
-    
+public enum TUSClientError: Error, LocalizedError {
+
     case couldNotCopyFile(underlyingError: Error)
     case couldNotStoreFile(underlyingError: Error)
     case fileSizeUnknown
     case couldNotLoadData(underlyingError: Error)
     case couldNotStoreFileMetadata(underlyingError: Error)
-    case couldNotCreateFileOnServer
+    case couldNotCreateFileOnServer(underlyingError: Error)
     case couldNotUploadFile(underlyingError: Error)
     case couldNotGetFileStatus
     case fileSizeMismatchWithServer
@@ -36,8 +36,8 @@ public enum TUSClientError: Error {
             return "Could not load data: \(underlyingError.localizedDescription)"
         case .couldNotStoreFileMetadata(let underlyingError):
             return "Could not store file metadata: \(underlyingError.localizedDescription)"
-        case .couldNotCreateFileOnServer:
-            return "Could not create file on server."
+        case .couldNotCreateFileOnServer(let underlyingError):
+            return "Could not create file on server: (\(underlyingError.localizedDescription))"
         case .couldNotUploadFile(let underlyingError):
             return "Could not upload file: \(underlyingError.localizedDescription)"
         case .couldNotGetFileStatus:
@@ -67,5 +67,9 @@ public enum TUSClientError: Error {
         case .customURLSessionWithBackgroundConfigurationNotSupported:
             return "Custom URLSession with background configuration is not supported."
         }
+    }
+
+    public var errorDescription: String? {
+        localizedDescription
     }
 }

--- a/Sources/TUSKit/Tasks/CreationTask.swift
+++ b/Sources/TUSKit/Tasks/CreationTask.swift
@@ -70,7 +70,7 @@ final class CreationTask: IdentifiableTask {
                     } catch let error as TUSClientError {
                         completed(.failure(error))
                     } catch {
-                        completed(.failure(TUSClientError.couldNotCreateFileOnServer))
+                        completed(.failure(TUSClientError.couldNotCreateFileOnServer(underlyingError: error)))
                     }
                 }
             }


### PR DESCRIPTION
This PR provides the body of failed requests in upload errors (if provided) to make it easier to diagnose upload issues.

* Update SessionDataDelegate to call `handleTaskCompletion` when `didReceiveData` is called, passing the data
* Forward the data in `failedRequest` error
* Include the data as a string in the localizedDescription of `failedRequest`
* Pass the underlying error to `couldNotCreateFileOnServer`
* TUSAPIError and TUSClientError conform to LocalizedError

The error message could probably be cleaned up, but wanted to get this up as a first pass.

Closes #https://github.com/tus/TUSKit/issues/212
