### PR TITLE
Wire up progress after re-launch using URLSession delegate

### DIFF
--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -67,8 +67,11 @@ final class TUSAPI {
     private var backgroundHandler: (() -> Void)? = nil
     private var callbacks: [String: (Result<(Data?, HTTPURLResponse), Error>) -> Void] = [:]
     private var taskData: [String: Data] = [:]
+    private var progressObservations: [String: NSKeyValueObservation] = [:]
+    weak var progressDelegate: ProgressDelegate?
 
     deinit {
+        progressObservations.values.forEach { $0.invalidate() }
         if session.delegate is SessionDataDelegate {
             session.finishTasksAndInvalidate()
         }
@@ -285,6 +288,8 @@ final class TUSAPI {
         task.taskDescription = metaData.id.uuidString
         if #available(iOS 15.0, macOS 12, *), !session.configuration.sessionSendsLaunchEvents {
             task.delegate = sessionDelegate
+        } else if !(session.delegate is SessionDataDelegate) {
+            observeProgressForCompatibility(task: task, totalBytesExpectedToSend: Int64(data.count))
         }
         
         queue.sync {
@@ -336,12 +341,14 @@ final class TUSAPI {
         task.taskDescription = metaData.id.uuidString
         if #available(iOS 15.0, macOS 12, *), !session.configuration.sessionSendsLaunchEvents {
             task.delegate = sessionDelegate
+        } else if !(session.delegate is SessionDataDelegate) {
+            observeProgressForCompatibility(task: task, totalBytesExpectedToSend: Int64(length))
         }
         
         queue.sync {
             self.callbacks[metaData.id.uuidString] = { result in
                 processResult(completion: completion) {
-                    let (data, response) = try result.get()
+                    let (_, response) = try result.get()
                     guard let offsetStr = response.allHeaderFields[caseInsensitive: "upload-offset"] as? String,
                           let offset = Int(offsetStr) else {
                         throw TUSAPIError.couldNotRetrieveOffset
@@ -353,12 +360,30 @@ final class TUSAPI {
         task.resume()
         return task
     }
-    
+
+    func observeProgressForCompatibility(task: URLSessionTask, totalBytesExpectedToSend: Int64) {
+        guard let identifier = task.taskDescription else { return }
+
+        let observation = task.progress.observe(\.completedUnitCount) { [weak self, weak task] progress, _ in
+            guard let self, let task else { return }
+            self.handleProgressForTask(task, totalBytesSent: progress.completedUnitCount, totalBytesExpectedToSend: totalBytesExpectedToSend)
+        }
+
+        queue.sync {
+            progressObservations[identifier] = observation
+        }
+    }
+
+    func handleProgressForTask(_ task: URLSessionTask, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        guard let identifier = task.taskDescription, let id = UUID(uuidString: identifier) else { return }
+        progressDelegate?.progressUpdated(forID: id, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+    }
+
     func registerCallback(_ completion: @escaping (Result<Int, TUSAPIError>) -> Void, forMetadata metadata: UploadMetadata) {
         queue.sync {
             self.callbacks[metadata.id.uuidString] = { result in
                 processResult(completion: completion) {
-                    let (data, response) = try result.get()
+                    let (_, response) = try result.get()
                     guard let offsetStr = response.allHeaderFields[caseInsensitive: "upload-offset"] as? String,
                           let offset = Int(offsetStr) else {
                         throw TUSAPIError.couldNotRetrieveOffset
@@ -442,7 +467,7 @@ extension Dictionary {
     }
 }
 
-private extension TUSAPI {
+extension TUSAPI {
     final class SessionDataDelegate: NSObject, URLSessionDataDelegate {
         weak var api: TUSAPI?
 
@@ -454,35 +479,40 @@ private extension TUSAPI {
             api.taskData[identifier, default: Data()].append(data)
         }
 
+        func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+            api?.handleProgressForTask(task, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+        }
+
         func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
             api?.handleCompletionOfTask(task, withError: error)
         }
-        
+
         func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
             api?.handleFinishOfBackgroundURLSessionEvents()
         }
     }
-    
+
     func handleCompletionOfTask(_ task: URLSessionTask, withError error: Error?) {
         queue.sync {
             guard let identifier = task.taskDescription else {
                 return
             }
-            
+
             defer {
                 callbacks.removeValue(forKey: identifier)
                 taskData.removeValue(forKey: identifier)
+                progressObservations.removeValue(forKey: identifier)
             }
-            
+
             guard let completion = callbacks[identifier] else {
                 return
             }
-            
+
             if let error = error {
                 completion(.failure(TUSAPIError.underlyingError(error)))
                 return
             }
-            
+
             guard let response = task.response as? HTTPURLResponse else {
                 completion(.failure(TUSAPIError.underlyingError(NetworkError.noHTTPURLResponse)))
                 return
@@ -493,7 +523,7 @@ private extension TUSAPI {
             completion(.success(success))
         }
     }
-    
+
     func handleFinishOfBackgroundURLSessionEvents() {
         if let backgroundHandler {
             DispatchQueue.main.async {

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -38,10 +38,8 @@ public protocol TUSClientDelegate: AnyObject {
     /// - Important: The total is based on active uploads, so it will lower once files are uploaded. This is because it's ambiguous what the total is. E.g. You can be uploading 100 bytes, after 50 bytes are uploaded, let's say you add 150 more bytes, is the total then 250 or 200? And what if the upload is done, and you add 50 more. Is the total 50 or 300? or 250?
     ///
     /// As a rule of thumb: The total will be highest on the start, a good starting point is to compare the progress against that number.
-    @available(iOS 11.0, macOS 10.13, watchOS 6.0, *)
     func totalProgress(bytesUploaded: Int, totalBytes: Int, client: TUSClient)
-    
-    @available(iOS 11.0, macOS 10.13, watchOS 6.0, *)
+
     /// Get the progress of a specific upload by id. The id is given when adding an upload and methods of this delegate.
     func progressFor(id: UUID, context: [String: String]?, bytesUploaded: Int, totalBytes: Int, client: TUSClient)
 }
@@ -57,8 +55,7 @@ public extension TUSClientDelegate {
 }
 
 protocol ProgressDelegate: AnyObject {
-    @available(iOS 11.0, macOS 10.13, watchOS 6.0, *)
-    func progressUpdatedFor(metaData: UploadMetadata, totalUploadedBytes: Int)
+    func progressUpdated(forID id: UUID, totalBytesSent: Int64, totalBytesExpectedToSend: Int64)
 }
 
 /// The TUSKit client.
@@ -89,9 +86,9 @@ public final class TUSClient {
     private let api: TUSAPI
     private let chunkSize: Int?
     /// Keep track of uploads and their id's
-    private var uploads = [UUID: UploadMetadata]()
+    var uploads = [UUID: UploadMetadata]()
     private let queue = DispatchQueue(label: "com.TUSKit.TUSClient")
-    private let reportingQueue: DispatchQueue
+    let reportingQueue: DispatchQueue
     private let headerGenerator: HeaderGenerator
 
     /// Initialize a TUSClient with support for background URLSessions and uploads
@@ -136,9 +133,10 @@ public final class TUSClient {
         self.reportingQueue = reportingQueue
         self.headerGenerator = HeaderGenerator(handler: generateHeaders)
         scheduler.delegate = self
+        self.api.progressDelegate = self
         reregisterCallbacks()
     }
-    
+
     /// Initialize a TUSClient
     /// - Parameters:
     ///   - server: The URL of the server where you want to upload to.
@@ -171,6 +169,7 @@ public final class TUSClient {
         self.reportingQueue = reportingQueue
         self.headerGenerator = HeaderGenerator(handler: generateHeaders)
         scheduler.delegate = self
+        self.api.progressDelegate = self
         removeFinishedUploads()
         reregisterCallbacks()
     }
@@ -209,10 +208,11 @@ public final class TUSClient {
         self.reportingQueue = reportingQueue
         self.headerGenerator = HeaderGenerator(handler: generateHeaders)
         scheduler.delegate = self
+        self.api.progressDelegate = self
         removeFinishedUploads()
         reregisterCallbacks()
     }
-    
+
     // MARK: - Starting and stopping
     
     /// Kick off the client to start uploading any locally stored files.
@@ -546,7 +546,7 @@ public final class TUSClient {
         guard let allMetadata = try? files.loadAllMetadata() else {
             return
         }
-        
+
         for metadata in allMetadata {
             api.checkTaskExists(for: metadata) { [weak self] taskExists in
                 guard let self else {
@@ -556,11 +556,13 @@ public final class TUSClient {
                       let task = try? UploadDataTask(api: self.api, metaData: metadata, files: self.files, headerGenerator: self.headerGenerator) else {
                     return
                 }
-                
+
+                self.queue.sync { self.uploads[metadata.id] = metadata }
+
                 self.api.registerCallback({ result in
                     task.taskCompleted(result: result, completed: { [weak self] result in
                         if case .failure = result {
-                            try? self?.retry(id: metadata.id)
+                            _ = try? self?.retry(id: metadata.id)
                         }
                     })
                 }, forMetadata: metadata)
@@ -605,7 +607,7 @@ public final class TUSClient {
             }
         }
         
-        guard let task = try taskFor(metaData: metaData, api: api, files: files, chunkSize: chunkSize, progressDelegate: self, headerGenerator: headerGenerator) else {
+        guard let task = try taskFor(metaData: metaData, api: api, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator) else {
             assertionFailure("Could not find a task for metaData \(metaData)")
             return
         }
@@ -664,7 +666,7 @@ public final class TUSClient {
     /// Schedule a single task if needed. Will decide what task to schedule for the metaData.
     /// - Parameter metaData:The metaData the schedule.
     private func scheduleTask(for metaData: UploadMetadata) throws {
-        guard let task = try taskFor(metaData: metaData, api: api, files: files, chunkSize: chunkSize, progressDelegate: self, headerGenerator: headerGenerator) else {
+        guard let task = try taskFor(metaData: metaData, api: api, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator) else {
             throw TUSClientError.uploadIsAlreadyFinished
         }
         queue.sync {
@@ -826,26 +828,30 @@ private extension String {
 /// Decide which task to create based on metaData.
 /// - Parameter metaData: The `UploadMetadata` for which to create a `Task`.
 /// - Returns: The task that has to be performed for the relevant metaData. Will return nil if metaData's file is already uploaded / finished. (no task needed).
-func taskFor(metaData: UploadMetadata, api: TUSAPI, files: Files, chunkSize: Int?, progressDelegate: ProgressDelegate? = nil, headerGenerator: HeaderGenerator) throws -> ScheduledTask? {
+func taskFor(metaData: UploadMetadata, api: TUSAPI, files: Files, chunkSize: Int?, headerGenerator: HeaderGenerator) throws -> ScheduledTask? {
     guard !metaData.isFinished else {
         return nil
     }
-    
+
     if let remoteDestination = metaData.remoteDestination {
-        let statusTask = StatusTask(api: api, remoteDestination: remoteDestination, metaData: metaData, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator)
-        statusTask.progressDelegate = progressDelegate
-        return statusTask
+        return StatusTask(api: api, remoteDestination: remoteDestination, metaData: metaData, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator)
     } else {
-        let creationTask = try CreationTask(metaData: metaData, api: api, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator)
-        creationTask.progressDelegate = progressDelegate
-        return creationTask
+        return try CreationTask(metaData: metaData, api: api, files: files, chunkSize: chunkSize, headerGenerator: headerGenerator)
     }
 }
 
 extension TUSClient: ProgressDelegate {
-    
-    @available(iOS 11.0, macOS 10.13, watchOS 6.0, *)
-    func progressUpdatedFor(metaData: UploadMetadata, totalUploadedBytes: Int) {
+
+    func progressUpdated(forID id: UUID, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        var metaData: UploadMetadata?
+        queue.sync {
+            metaData = self.uploads[id]
+        }
+        guard let metaData else { return }
+
+        let alreadyUploaded = metaData.uploadedRange?.count ?? 0
+        let totalUploadedBytes = alreadyUploaded + Int(totalBytesSent)
+
         reportingQueue.async {
             self.delegate?.progressFor(id: metaData.id, context: metaData.context, bytesUploaded: totalUploadedBytes, totalBytes: metaData.size, client: self)
         }
@@ -858,10 +864,7 @@ extension TUSClient: ProgressDelegate {
             uploadsCopy = self.uploads
         }
         for (_, metaDataForTotal) in uploadsCopy {
-            guard metaDataForTotal.id != metaData.id else {
-                continue
-            }
-
+            guard metaDataForTotal.id != id else { continue }
             totalBytesUploaded += metaDataForTotal.uploadedRange?.count ?? 0
             totalSize += metaDataForTotal.size
         }

--- a/Sources/TUSKit/Tasks/CreationTask.swift
+++ b/Sources/TUSKit/Tasks/CreationTask.swift
@@ -17,7 +17,6 @@ final class CreationTask: IdentifiableTask {
         metaData.id
     }
     
-    weak var progressDelegate: ProgressDelegate?
     let metaData: UploadMetadata
     
     private let api: TUSAPI
@@ -56,7 +55,6 @@ final class CreationTask: IdentifiableTask {
                             let files = self.files
                             let chunkSize = self.chunkSize
                             let api = self.api
-                            let progressDelegate = self.progressDelegate
 
                             do {
                                 let remoteDestination = try result.get()
@@ -69,7 +67,6 @@ final class CreationTask: IdentifiableTask {
                                 } else {
                                     task = try UploadDataTask(api: api, metaData: metaData, files: files, headerGenerator: self.headerGenerator)
                                 }
-                                task.progressDelegate = progressDelegate
                                 if self.didCancel {
                                     completed(.failure(TUSClientError.taskCancelled))
                                 } else {

--- a/Sources/TUSKit/Tasks/StatusTask.swift
+++ b/Sources/TUSKit/Tasks/StatusTask.swift
@@ -16,7 +16,6 @@ final class StatusTask: IdentifiableTask {
         metaData.id
     }
     
-    weak var progressDelegate: ProgressDelegate?
     let api: TUSAPI
     let files: Files
     let remoteDestination: URL
@@ -57,7 +56,6 @@ final class StatusTask: IdentifiableTask {
                             let files = self.files
                             let chunkSize = self.chunkSize
                             let api = self.api
-                            let progressDelegate = self.progressDelegate
 
                             do {
                                 let status = try result.get()
@@ -92,7 +90,6 @@ final class StatusTask: IdentifiableTask {
                                     }
 
                                     let task = try UploadDataTask(api: api, metaData: metaData, files: files, range: nextRange, headerGenerator: self.headerGenerator)
-                                    task.progressDelegate = progressDelegate
                                     completed(.success([task]))
                                 }
                             } catch let error as TUSClientError {

--- a/Sources/TUSKit/Tasks/UploadDataTask.swift
+++ b/Sources/TUSKit/Tasks/UploadDataTask.swift
@@ -17,17 +17,15 @@ final class UploadDataTask: NSObject, IdentifiableTask {
         metaData.id
     }
     
-    weak var progressDelegate: ProgressDelegate?
     let metaData: UploadMetadata
     
     let queue = DispatchQueue(label: "com.tuskit.uploadDataTask")
     
     private var isCanceled = false
-    
+
     private let api: TUSAPI
     private let files: Files
     private let range: Range<Int>?
-    private var observation: NSKeyValueObservation?
     private weak var sessionTask: URLSessionUploadTask?
     private let headerGenerator: HeaderGenerator
     
@@ -81,12 +79,8 @@ final class UploadDataTask: NSObject, IdentifiableTask {
                 return
             }
 
-            let dataSize: Int
             let file: URL
             do {
-                let attr = try FileManager.default.attributesOfItem(atPath: self.metaData.filePath.path)
-                dataSize = attr[FileAttributeKey.size] as! Int
-
                 file = try self.prepareUploadFile()
             } catch let error {
                 completed(Result.failure(TUSClientError.couldNotLoadData(underlyingError: error)))
@@ -110,19 +104,11 @@ final class UploadDataTask: NSObject, IdentifiableTask {
                         guard let self else { return }
 
                         self.queue.async {
-                            self.observation?.invalidate()
                             self.taskCompleted(result: result, completed: completed)
                         }
                     }
 
-                    task.taskDescription = "\(self.metaData.id)"
-                    task.resume()
-
                     self.sessionTask = task
-
-                    if #available(iOS 11.0, macOS 10.13, *) {
-                        self.observeTask(task: task, size: self.range?.count ?? dataSize)
-                    }
                 }
             }
         }
@@ -162,28 +148,11 @@ final class UploadDataTask: NSObject, IdentifiableTask {
             }
 
             let task = try UploadDataTask(api: api, metaData: metaData, files: files, range: nextRange, headerGenerator: headerGenerator)
-            task.progressDelegate = progressDelegate
             completed(.success([task]))
         } catch let error as TUSClientError {
             completed(.failure(error))
         } catch {
             completed(.failure(TUSClientError.couldNotUploadFile(underlyingError: error)))
-        }
-    }
-    
-    @available(iOS 11.0, macOS 10.13, *)
-    func observeTask(task: URLSessionUploadTask, size: Int) {
-        let targetRange = 0..<size
-        let uploaded = metaData.uploadedRange?.count ?? 0
-        
-        observation = task.progress.observe(\.fractionCompleted) { [weak self] progress, _ in
-            guard let self = self else { return }
-            self.queue.async {
-                guard progress.fractionCompleted <= 1 else { return }
-                let bytes = progress.fractionCompleted * Double(targetRange.count)
-                let totalUploaded = uploaded + Int(bytes)
-                self.progressDelegate?.progressUpdatedFor(metaData: self.metaData, totalUploadedBytes: totalUploaded)
-            }
         }
     }
     
@@ -232,12 +201,7 @@ final class UploadDataTask: NSObject, IdentifiableTask {
     func cancel() {
         queue.async {
             self.isCanceled = true
-            self.observation?.invalidate()
             self.sessionTask?.cancel()
         }
-    }
-    
-    deinit {
-        observation?.invalidate()
     }
 }

--- a/Tests/TUSKitTests/Mocks.swift
+++ b/Tests/TUSKitTests/Mocks.swift
@@ -72,6 +72,23 @@ final class TUSMockDelegate: TUSClientDelegate {
     }
 }
 
+/// A minimal URLSessionTask stub with a fixed taskDescription, used to drive TUSAPI's
+/// progress and completion routing in tests without a live URLSession.
+final class MockURLSessionTask: URLSessionTask, @unchecked Sendable {
+    private let _taskDescription: String?
+    override var taskDescription: String? {
+        get { _taskDescription }
+        set { }
+    }
+
+    init(taskDescription: String?) {
+        _taskDescription = taskDescription
+        // URLSessionTask.init() is deprecated in macOS 10.15 but there's no
+        // alternative designated initializer for subclassing in test code.
+        super.init()
+    }
+}
+
 typealias Headers = [String: String]?
 
 /// MockURLProtocol to support mocking the network

--- a/Tests/TUSKitTests/TUSAPITests.swift
+++ b/Tests/TUSKitTests/TUSAPITests.swift
@@ -158,6 +158,87 @@ final class TUSAPITests: XCTestCase {
         XCTAssertEqual(String(length), headerFields["Content-Length"])
     }
     
+    // MARK: - Progress delegate
+
+    func testProgressDelegateFiredViaHandleProgressForTask() {
+        let id = UUID()
+        var receivedID: UUID?
+        var receivedSent: Int64 = 0
+        var receivedExpected: Int64 = 0
+        let delegateExpectation = expectation(description: "progress delegate fires")
+
+        let mockDelegate = MockProgressDelegate { firedID, sent, expected in
+            receivedID = firedID
+            receivedSent = sent
+            receivedExpected = expected
+            delegateExpectation.fulfill()
+        }
+        api.progressDelegate = mockDelegate
+
+        let task = MockURLSessionTask(taskDescription: id.uuidString)
+        api.handleProgressForTask(task, totalBytesSent: 512, totalBytesExpectedToSend: 1024)
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(receivedID, id)
+        XCTAssertEqual(receivedSent, 512)
+        XCTAssertEqual(receivedExpected, 1024)
+    }
+
+    func testCompatibilityProgressObservationRoutesProgressWhenDelegateCallbacksAreUnavailable() {
+        let id = UUID()
+        var receivedID: UUID?
+        var receivedSent: Int64 = 0
+        var receivedExpected: Int64 = 0
+        let delegateExpectation = expectation(description: "progress delegate fires")
+
+        let mockDelegate = MockProgressDelegate { firedID, sent, expected in
+            receivedID = firedID
+            receivedSent = sent
+            receivedExpected = expected
+            delegateExpectation.fulfill()
+        }
+        api.progressDelegate = mockDelegate
+
+        let task = MockURLSessionTask(taskDescription: id.uuidString)
+        api.observeProgressForCompatibility(task: task, totalBytesExpectedToSend: 1024)
+
+        task.progress.totalUnitCount = 1024
+        task.progress.completedUnitCount = 512
+
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(receivedID, id)
+        XCTAssertEqual(receivedSent, 512)
+        XCTAssertEqual(receivedExpected, 1024)
+    }
+
+    func testProgressDelegateNotCalledForNilTaskDescription() {
+        var callCount = 0
+        let mockDelegate = MockProgressDelegate { _, _, _ in callCount += 1 }
+        api.progressDelegate = mockDelegate
+
+        let task = MockURLSessionTask(taskDescription: nil)
+        api.handleProgressForTask(task, totalBytesSent: 512, totalBytesExpectedToSend: 1024)
+
+        let flush = expectation(description: "flush")
+        DispatchQueue.main.async { flush.fulfill() }
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(callCount, 0)
+    }
+
+    func testProgressDelegateNotCalledForInvalidUUIDTaskDescription() {
+        var callCount = 0
+        let mockDelegate = MockProgressDelegate { _, _, _ in callCount += 1 }
+        api.progressDelegate = mockDelegate
+
+        let task = MockURLSessionTask(taskDescription: "not-a-uuid")
+        api.handleProgressForTask(task, totalBytesSent: 512, totalBytesExpectedToSend: 1024)
+
+        let flush = expectation(description: "flush")
+        DispatchQueue.main.async { flush.fulfill() }
+        waitForExpectations(timeout: 1)
+        XCTAssertEqual(callCount, 0)
+    }
+
     func testUploadWithRelativePath() throws {
         let data = Data("Hello how are you".utf8)
         let baseURL = URL(string: "https://tus.example.org/files")!
@@ -190,5 +271,19 @@ final class TUSAPITests: XCTestCase {
         XCTAssertEqual(String(offset), headerFields["Upload-Offset"])
         XCTAssertEqual(String(length), headerFields["Content-Length"])
     }
-    
+
+}
+
+// MARK: - Helpers
+
+private final class MockProgressDelegate: ProgressDelegate {
+    private let handler: (UUID, Int64, Int64) -> Void
+
+    init(_ handler: @escaping (UUID, Int64, Int64) -> Void) {
+        self.handler = handler
+    }
+
+    func progressUpdated(forID id: UUID, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        handler(id, totalBytesSent, totalBytesExpectedToSend)
+    }
 }

--- a/Tests/TUSKitTests/TUSClient/TUSClientInternalTests.swift
+++ b/Tests/TUSKitTests/TUSClient/TUSClientInternalTests.swift
@@ -146,6 +146,30 @@ final class TUSClientInternalTests: XCTestCase {
         XCTAssertTrue(resumed.isEmpty)
     }
     
+    func testProgressUpdatedIncludesAlreadyUploadedOffset() throws {
+        let id = UUID()
+        let filePath = try files.store(data: data, id: id)
+        let alreadyUploaded = 5
+        let metaData = UploadMetadata(
+            id: id,
+            filePath: filePath,
+            uploadURL: URL(string: "https://tus.example.net/files")!,
+            size: data.count,
+            customHeaders: [:],
+            mimeType: nil
+        )
+        metaData.uploadedRange = 0..<alreadyUploaded
+        client.uploads[id] = metaData
+
+        client.progressUpdated(forID: id, totalBytesSent: 3, totalBytesExpectedToSend: Int64(data.count - alreadyUploaded))
+
+        let flush = expectation(description: "reporting queue flushed")
+        client.reportingQueue.async { flush.fulfill() }
+        waitForExpectations(timeout: 1)
+
+        XCTAssertEqual(tusDelegate.progressPerId[id], alreadyUploaded + 3)
+    }
+
     func testCancellationDoesNotIncrementErrorCountOrRetry() throws {
         let metaData = try storeFiles()
         let creationTask = try CreationTask(metaData: metaData,


### PR DESCRIPTION
Rather than using KVO on the task to monitor progress, we now use URLSession's delegate method which can survive a relaunch. There's no way to reconstruct the upload task so this is the only durable method. KVO observation is kept as a compatibility fallback for the deprecated `TUSClient.init` that accepts a URLSession.

Adds some tests and cleans up the progress callback registry. More can be cleaned up after `TUSClient.init(session:)` is removed.

Disclosure: assisted by Claude Code and Codex

Closes #227