### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/tuskit-ci.yml
+++ b/.github/workflows/tuskit-ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Extract Branch Name
         run: echo "BRANCH=$(echo ${GITHUB_REF##*/})" >> $GITHUB_ENV
-      - uses: swift-actions/setup-swift@v2
+      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a
         with:
           swift-version: ${{ matrix.swift }}
       - name: Get swift version


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/tuskit-ci.yml`

Resolved refs:

- `swift-actions/setup-swift@v2` -> `swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
